### PR TITLE
Support Enzyme forward + reverse mode

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,7 @@ version = "0.1.6"
 julia = "1"
 
 [extras]
-EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["EnzymeCore", "Test"]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,13 @@
 name = "ADTypes"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.1.5"
+version = "0.1.6"
+
+[deps]
+EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
 
 [compat]
+EnzymeCore = "0.1, 0.2, 0.3, 0.4, 0.5"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -3,15 +3,12 @@ uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 version = "0.1.6"
 
-[deps]
-EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
-
 [compat]
-EnzymeCore = "0.1, 0.2, 0.3, 0.4, 0.5"
 julia = "1"
 
 [extras]
+EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["EnzymeCore", "Test"]

--- a/src/ADTypes.jl
+++ b/src/ADTypes.jl
@@ -1,7 +1,5 @@
 module ADTypes
 
-import EnzymeCore
-
 """
 Base type for AD choices.
 """
@@ -32,11 +30,11 @@ AutoReverseDiff(; compile = false) = AutoReverseDiff(compile)
 
 struct AutoZygote <: AbstractADType end
 
-struct AutoEnzyme{M <: EnzymeCore.Mode} <: AbstractADType
+struct AutoEnzyme{M} <: AbstractADType
     mode::M
 end
 
-AutoEnzyme(; mode::EnzymeCore.Mode = EnzymeCore.Reverse) = AutoEnzyme(mode)
+AutoEnzyme(; mode = nothing) = AutoEnzyme(mode)
 
 struct AutoTracker <: AbstractADType end
 

--- a/src/ADTypes.jl
+++ b/src/ADTypes.jl
@@ -1,5 +1,7 @@
 module ADTypes
 
+import EnzymeCore
+
 """
 Base type for AD choices.
 """
@@ -30,7 +32,11 @@ AutoReverseDiff(; compile = false) = AutoReverseDiff(compile)
 
 struct AutoZygote <: AbstractADType end
 
-struct AutoEnzyme <: AbstractADType end
+struct AutoEnzyme{M <: EnzymeCore.Mode} <: AbstractADType
+    mode::M
+end
+
+AutoEnzyme(; mode::EnzymeCore.Mode = EnzymeCore.Reverse) = AutoEnzyme(mode)
 
 struct AutoTracker <: AbstractADType end
 
@@ -51,5 +57,6 @@ function AutoSparseForwardDiff(chunksize = nothing)
     AutoSparseForwardDiff{chunksize}()
 end
 
-export AutoFiniteDiff, AutoForwardDiff, AutoReverseDiff, AutoZygote, AutoEnzyme, AutoTracker, AutoModelingToolkit, AutoSparseFiniteDiff, AutoSparseForwardDiff
+export AutoFiniteDiff, AutoForwardDiff, AutoReverseDiff, AutoZygote, AutoEnzyme,
+       AutoTracker, AutoModelingToolkit, AutoSparseFiniteDiff, AutoSparseForwardDiff
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,6 @@
 using ADTypes
 using Test
 
-import EnzymeCore
-
 @testset "ADTypes.jl" begin
     adtype = AutoFiniteDiff()
     @test adtype isa ADTypes.AbstractADType
@@ -52,9 +50,11 @@ import EnzymeCore
     @test adtype isa ADTypes.AbstractADType
     @test adtype isa AutoEnzyme{Nothing}
 
-    adtype = AutoEnzyme(; mode = EnzymeCore.Reverse)
+    # In practice, you would rather specify a
+    # `mode::Enzyme.Mode`, e.g. `Enzyme.Reverse` or `Enzyme.Forward`
+    adtype = AutoEnzyme(; mode = Val(:Reverse))
     @test adtype isa ADTypes.AbstractADType
-    @test adtype isa AutoEnzyme{<:EnzymeCore.ReverseMode}
+    @test adtype isa AutoEnzyme{Val{:Reverse}}
 
     adtype = AutoModelingToolkit()
     @test adtype isa ADTypes.AbstractADType

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,11 +39,11 @@ import EnzymeCore
 
     adtype = AutoEnzyme()
     @test adtype isa ADTypes.AbstractADType
-    @test adtype isa AutoEnzyme{<:EnzymeCore.ReverseMode}
+    @test adtype isa AutoEnzyme{Nothing}
 
-    adtype = AutoEnzyme(; mode = EnzymeCore.Forward)
+    adtype = AutoEnzyme(; mode = EnzymeCore.Reverse)
     @test adtype isa ADTypes.AbstractADType
-    @test adtype isa AutoEnzyme{<:EnzymeCore.ForwardMode}
+    @test adtype isa AutoEnzyme{<:EnzymeCore.ReverseMode}
 
     adtype = AutoModelingToolkit()
     @test adtype isa ADTypes.AbstractADType

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,18 +1,33 @@
 using ADTypes
 using Test
 
+import EnzymeCore
+
 @testset "ADTypes.jl" begin
     adtype = AutoFiniteDiff()
     @test adtype isa ADTypes.AbstractADType
     @test adtype isa AutoFiniteDiff
+    @test adtype.fdtype === Val(:forward)
+    @test adtype.fdjtype === Val(:forward)
+    @test adtype.fdhtype === Val(:hcentral)
 
     adtype = AutoForwardDiff()
     @test adtype isa ADTypes.AbstractADType
-    @test adtype isa AutoForwardDiff
+    @test adtype isa AutoForwardDiff{nothing}
+
+    adtype = AutoForwardDiff(10)
+    @test adtype isa ADTypes.AbstractADType
+    @test adtype isa AutoForwardDiff{10}
 
     adtype = AutoReverseDiff()
     @test adtype isa ADTypes.AbstractADType
     @test adtype isa AutoReverseDiff
+    @test !adtype.compile
+
+    adtype = AutoReverseDiff(; compile = true)
+    @test adtype isa ADTypes.AbstractADType
+    @test adtype isa AutoReverseDiff
+    @test adtype.compile
 
     adtype = AutoZygote()
     @test adtype isa ADTypes.AbstractADType
@@ -21,4 +36,36 @@ using Test
     adtype = AutoTracker()
     @test adtype isa ADTypes.AbstractADType
     @test adtype isa AutoTracker
+
+    adtype = AutoEnzyme()
+    @test adtype isa ADTypes.AbstractADType
+    @test adtype isa AutoEnzyme{<:EnzymeCore.ReverseMode}
+
+    adtype = AutoEnzyme(; mode = EnzymeCore.Forward)
+    @test adtype isa ADTypes.AbstractADType
+    @test adtype isa AutoEnzyme{<:EnzymeCore.ForwardMode}
+
+    adtype = AutoModelingToolkit()
+    @test adtype isa ADTypes.AbstractADType
+    @test adtype isa AutoModelingToolkit
+    @test !adtype.obj_sparse
+    @test !adtype.cons_sparse
+
+    adtype = AutoModelingToolkit(; obj_sparse = true, cons_sparse = true)
+    @test adtype isa ADTypes.AbstractADType
+    @test adtype isa AutoModelingToolkit
+    @test adtype.obj_sparse
+    @test adtype.cons_sparse
+
+    adtype = AutoSparseFiniteDiff()
+    @test adtype isa ADTypes.AbstractADType
+    @test adtype isa AutoSparseFiniteDiff
+
+    adtype = AutoSparseForwardDiff()
+    @test adtype isa ADTypes.AbstractADType
+    @test adtype isa AutoSparseForwardDiff{nothing}
+
+    adtype = AutoSparseForwardDiff(10)
+    @test adtype isa ADTypes.AbstractADType
+    @test adtype isa AutoSparseForwardDiff{10}
 end


### PR DESCRIPTION
Fixes #9 and adds more tests.

I chose to not introduce any new types but instead added a field to `AutoEnzyme` (and hence an additional type parameter which makes the PR technically breaking but I'm not sure how widespread the use of `AutoEnzyme` is within the community and if there are any examples that would actually break?). The advantage is that one could even specify other modes than `Enzyme.Forward` and `Enzyme.Reverse` such as `Enzyme.ReverseWithPrimal`.

Since I set the default value to `EnzymeCore.Reverse`, a dependency on `EnzymeCore` is added. Even though it is lightweight (only depends on Adapt and I'm about to open a PR that would make it a weak dependency on Julia >= 1.9, so if accepted the package would have zero dependencies on Julia >= 1.9) this might not be desirable. An alternative would be to use a default value of `nothing` instead and to not explicitly restrict the field to `EnzymeCore.Mode`.

Edit: In CI I noticed another issue with EnzymeCore - it breaks compatibility with Julia < 1.6. On the other hand, in these versions `AutoEnzyme` is not useful at all since Enzyme >= 0.4 (currently at 0.11.5) does only support Julia >= 1.6.

Edit 2: Yet another possibility would be to not restrict the type of the field and move the convenience constructor to an extension such that at least on Julia >= 1.9 no hard dependencies are added while still keeping a more meaningful default than `nothing`. On Julia < 1.9 and >= 1.6, this constructor could be hidden behind a requires-block or EnzymeCore could be kept as a direct dependency in these older versions. On Julia < 1.6, the convenience constructor could still not be supported (but as mentioned on these the whole `AutoEnzyme` type is not useful anyway).