### PR TITLE
Add AD type for FiniteDifferences

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ADTypes"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.1.5"
+version = "0.1.6"
 
 [compat]
 julia = "1"

--- a/src/ADTypes.jl
+++ b/src/ADTypes.jl
@@ -16,6 +16,12 @@ function AutoFiniteDiff(; fdtype = Val(:forward), fdjtype = fdtype,
     AutoFiniteDiff(fdtype, fdjtype, fdhtype)
 end
 
+struct AutoFiniteDifferences{T} <: AbstractADType
+    fdm::T
+end
+
+AutoFiniteDifferences(; fdm = nothing) = AutoFiniteDifferences(fdm)
+
 struct AutoForwardDiff{chunksize} <: AbstractADType end
 
 function AutoForwardDiff(chunksize = nothing)
@@ -51,5 +57,5 @@ function AutoSparseForwardDiff(chunksize = nothing)
     AutoSparseForwardDiff{chunksize}()
 end
 
-export AutoFiniteDiff, AutoForwardDiff, AutoReverseDiff, AutoZygote, AutoEnzyme, AutoTracker, AutoModelingToolkit, AutoSparseFiniteDiff, AutoSparseForwardDiff
+export AutoFiniteDiff, AutoFiniteDifferences, AutoForwardDiff, AutoReverseDiff, AutoZygote, AutoEnzyme, AutoTracker, AutoModelingToolkit, AutoSparseFiniteDiff, AutoSparseForwardDiff
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,17 @@ using Test
     @test adtype isa ADTypes.AbstractADType
     @test adtype isa AutoFiniteDiff
 
+    adtype = AutoFiniteDifferences()
+    @test adtype isa ADTypes.AbstractADType
+    @test adtype isa AutoFiniteDifferences{Nothing}
+
+    # In practice, you would rather specify a
+    # `fdm::FiniteDifferences.FiniteDifferenceMethod`, e.g. constructed with
+    # `FiniteDifferences.central_fdm` or `FiniteDifferences.forward_fdm`
+    adtype = AutoFiniteDifferences(; fdm = Val(:forward))
+    @test adtype isa ADTypes.AbstractADType
+    @test adtype isa AutoFiniteDifferences{Val{:forward}}
+
     adtype = AutoForwardDiff()
     @test adtype isa ADTypes.AbstractADType
     @test adtype isa AutoForwardDiff


### PR DESCRIPTION
Maybe it would be reasonable to add a type for FiniteDifferences as well?

A bit inconsistent, in contrast to #10 in this PR I opted for a default value of `nothing` since I wanted to avoid pulling in FiniteDifferences which has much more dependencies than EnzymeCore. Alternatively, on Julia >= 1.9 one could add a weak dependency on FiniteDifferences and define a constructor with a more concrete default value such as `FiniteDifferences.central_fdm(5, 1)` (but this would lead to inconsistencies between Julia < 1.9 and >= 1.9...).