### PR TITLE
Add support for custom tags to ForwardDiff types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ADTypes"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.1.7"
+version = "0.1.6"
 
 [compat]
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ADTypes"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.1.6"
+version = "0.1.7"
 
 [compat]
 julia = "1"

--- a/src/ADTypes.jl
+++ b/src/ADTypes.jl
@@ -30,10 +30,6 @@ function AutoForwardDiff(; chunksize = nothing, tag = nothing)
     AutoForwardDiff{chunksize,typeof(tag)}(tag)
 end
 
-function AutoForwardDiff(chunksize = nothing; tag = nothing)
-    AutoForwardDiff{chunksize,typeof(tag)}(tag)
-end
-
 struct AutoReverseDiff <: AbstractADType
     compile::Bool
 end
@@ -67,10 +63,6 @@ end
 
 function AutoSparseForwardDiff(; chunksize = nothing, tag = nothing)
     AutoSparseForwardDiff{chunksize,typeof(tag)}(tag)
-end
-
-function AutoSparseForwardDiff(chunksize = nothing; tag = nothing)
-    AutoSparseForwardDiff{chunksize, typeof(tag)}(tag)
 end
 
 export AutoFiniteDiff, AutoFiniteDifferences, AutoForwardDiff, AutoReverseDiff, AutoZygote, AutoEnzyme, AutoTracker, AutoModelingToolkit, AutoSparseFiniteDiff, AutoSparseForwardDiff

--- a/src/ADTypes.jl
+++ b/src/ADTypes.jl
@@ -30,6 +30,10 @@ function AutoForwardDiff(; chunksize = nothing, tag = nothing)
     AutoForwardDiff{chunksize,typeof(tag)}(tag)
 end
 
+function AutoForwardDiff(chunksize = nothing; tag = nothing)
+    AutoForwardDiff{chunksize,typeof(tag)}(tag)
+end
+
 struct AutoReverseDiff <: AbstractADType
     compile::Bool
 end
@@ -63,6 +67,10 @@ end
 
 function AutoSparseForwardDiff(; chunksize = nothing, tag = nothing)
     AutoSparseForwardDiff{chunksize,typeof(tag)}(tag)
+end
+
+function AutoSparseForwardDiff(chunksize = nothing; tag = nothing)
+    AutoSparseForwardDiff{chunksize, typeof(tag)}(tag)
 end
 
 export AutoFiniteDiff, AutoFiniteDifferences, AutoForwardDiff, AutoReverseDiff, AutoZygote, AutoEnzyme, AutoTracker, AutoModelingToolkit, AutoSparseFiniteDiff, AutoSparseForwardDiff

--- a/src/ADTypes.jl
+++ b/src/ADTypes.jl
@@ -22,10 +22,12 @@ end
 
 AutoFiniteDifferences(; fdm = nothing) = AutoFiniteDifferences(fdm)
 
-struct AutoForwardDiff{chunksize} <: AbstractADType end
+struct AutoForwardDiff{chunksize,T} <: AbstractADType
+    tag::T
+end
 
-function AutoForwardDiff(chunksize = nothing)
-    AutoForwardDiff{chunksize}()
+function AutoForwardDiff(; chunksize = nothing, tag = nothing)
+    AutoForwardDiff{chunksize,typeof(tag)}(tag)
 end
 
 struct AutoReverseDiff <: AbstractADType
@@ -51,10 +53,12 @@ end
 
 struct AutoSparseFiniteDiff <: AbstractADType end
 
-struct AutoSparseForwardDiff{chunksize} <: AbstractADType end
+struct AutoSparseForwardDiff{chunksize,T} <: AbstractADType
+    tag::T
+end
 
-function AutoSparseForwardDiff(chunksize = nothing)
-    AutoSparseForwardDiff{chunksize}()
+function AutoSparseForwardDiff(; chunksize = nothing, tag = nothing)
+    AutoSparseForwardDiff{chunksize,typeof(tag)}(tag)
 end
 
 export AutoFiniteDiff, AutoFiniteDifferences, AutoForwardDiff, AutoReverseDiff, AutoZygote, AutoEnzyme, AutoTracker, AutoModelingToolkit, AutoSparseFiniteDiff, AutoSparseForwardDiff

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,11 +31,6 @@ struct CustomTag end
     @test adtype isa ADTypes.AbstractADType
     @test adtype isa AutoForwardDiff{10,CustomTag}
 
-    adtype = AutoForwardDiff(10)
-    @test adtype isa ADTypes.AbstractADType
-    @test adtype isa AutoForwardDiff{10}
-
-
     adtype = AutoReverseDiff()
     @test adtype isa ADTypes.AbstractADType
     @test adtype isa AutoReverseDiff
@@ -82,10 +77,6 @@ struct CustomTag end
     @test adtype isa ADTypes.AbstractADType
     @test adtype isa AutoSparseForwardDiff{nothing}
 
-    adtype = AutoSparseForwardDiff(10)
-    @test adtype isa ADTypes.AbstractADType
-    @test adtype isa AutoSparseForwardDiff{10}
-  
     adtype = AutoEnzyme()
     @test adtype isa ADTypes.AbstractADType
     @test adtype isa AutoEnzyme{Nothing}
@@ -95,5 +86,4 @@ struct CustomTag end
     adtype = AutoEnzyme(; mode = Val(:Reverse))
     @test adtype isa ADTypes.AbstractADType
     @test adtype isa AutoEnzyme{Val{:Reverse}}
-
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using ADTypes
 using Test
 
+struct CustomTag end
+
 @testset "ADTypes.jl" begin
     adtype = AutoFiniteDiff()
     @test adtype isa ADTypes.AbstractADType
@@ -19,7 +21,11 @@ using Test
 
     adtype = AutoForwardDiff()
     @test adtype isa ADTypes.AbstractADType
-    @test adtype isa AutoForwardDiff
+    @test adtype isa AutoForwardDiff{nothing,Nothing}
+
+    adtype = AutoForwardDiff(; chunksize = 10, tag = CustomTag())
+    @test adtype isa ADTypes.AbstractADType
+    @test adtype isa AutoForwardDiff{10,CustomTag}
 
     adtype = AutoReverseDiff()
     @test adtype isa ADTypes.AbstractADType
@@ -32,4 +38,12 @@ using Test
     adtype = AutoTracker()
     @test adtype isa ADTypes.AbstractADType
     @test adtype isa AutoTracker
+
+    adtype = AutoSparseForwardDiff()
+    @test adtype isa ADTypes.AbstractADType
+    @test adtype isa AutoSparseForwardDiff{nothing,Nothing}
+
+    adtype = AutoSparseForwardDiff(; chunksize = 10, tag = CustomTag())
+    @test adtype isa ADTypes.AbstractADType
+    @test adtype isa AutoSparseForwardDiff{10,CustomTag}
 end


### PR DESCRIPTION
Sometimes it can be desirable to use custom ForwardDiff tags: https://www.stochasticlifestyle.com/improved-forwarddiff-jl-stacktraces-with-package-tags/

This is done e.g. in Turing and OrdinaryDiffEq and supported by LogDensityProblemsAD.