### PR TITLE
Drop support for Julia < 1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 version = "0.2.4"
 
 [compat]
-julia = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ADTypes"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.2.4"
+version = "0.2.5"
 
 [compat]
 julia = "1.6"


### PR DESCRIPTION
We did it for CI in #13, but `compat` should be updated too.