### PR TITLE
Add AutoChainRules(ruleconfig)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ADTypes"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.2.6"
+version = "0.2.7"
 
 [compat]
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ADTypes"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.2.7"
+version = "0.2.6"
 
 [compat]
 julia = "1.6"

--- a/src/ADTypes.jl
+++ b/src/ADTypes.jl
@@ -14,6 +14,10 @@ abstract type AbstractSparseReverseMode <: AbstractReverseMode end
 abstract type AbstractSparseForwardMode <: AbstractForwardMode end
 abstract type AbstractSparseFiniteDifferences <: AbstractFiniteDifferencesMode end
 
+Base.@kwdef struct AutoChainRules{RC} <: AbstractADType
+    ruleconfig::RC
+end
+
 Base.@kwdef struct AutoFiniteDiff{T1, T2, T3} <: AbstractFiniteDifferencesMode
     fdtype::T1 = Val(:forward)
     fdjtype::T2 = fdtype
@@ -78,7 +82,8 @@ Base.@kwdef struct AutoSparseReverseDiff <: AbstractSparseReverseMode
     compile::Bool = false
 end
 
-export AutoFiniteDiff,
+export AutoChainRules,
+       AutoFiniteDiff,
        AutoFiniteDifferences,
        AutoForwardDiff,
        AutoReverseDiff,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,11 @@ using Test
 struct CustomTag end
 
 @testset "ADTypes.jl" begin
+    adtype = AutoChainRules(:ruleconfig_placeholder)
+    @test adtype isa ADTypes.AbstractADType
+    @test adtype isa AutoChainRules
+    @test adtype.ruleconfig == :ruleconfig_placeholder
+
     adtype = AutoFiniteDiff()
     @test adtype isa ADTypes.AbstractADType
     @test adtype isa AutoFiniteDiff


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This PR adds an `AutoChainRules` AD type. It is built from a `RuleConfig` to allow calling back into AD with `frule_via_ad` or `rrule_via_ad` (see https://juliadiff.org/ChainRulesCore.jl/stable/rule_author/superpowers/ruleconfig.html).
It does not inherit from `AbstractForwardMode` or `AbstractReverseMode` because it can be both.

A similar pattern was used in AbstractDifferentiation.jl

https://github.com/JuliaDiff/AbstractDifferentiation.jl/blob/2bc18d07eb5038c997a7f9253bc3f1457124710e/src/backends.jl#L64-L66