### PR TITLE
Add docstrings and list of exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,34 @@
 ADTypes.jl is a common system for implementing multi-valued logic for choosing which
 automatic differentiation library to use.
 
+## Which libraries are supported?
+
+Just run the following code in a Julia REPL to find out:
+
+```julia
+julia> using ADTypes
+
+julia> names(ADTypes)
+15-element Vector{Symbol}:
+ :ADTypes
+ :AutoEnzyme
+ :AutoFiniteDiff
+ :AutoFiniteDifferences
+ :AutoForwardDiff
+ :AutoModelingToolkit
+ :AutoPolyesterForwardDiff
+ :AutoReverseDiff
+ :AutoSparseFiniteDiff
+ :AutoSparseForwardDiff
+ :AutoSparsePolyesterForwardDiff
+ :AutoSparseReverseDiff
+ :AutoSparseZygote
+ :AutoTracker
+ :AutoZygote
+```
+
+Use the help mode of the Julia REPL to find out more about a specific library.
+
 ## Why Should Packages Adopt This?
 
 The current standard is to have a keyword argument with `autodiff = true` or `autodiff = false`.

--- a/src/ADTypes.jl
+++ b/src/ADTypes.jl
@@ -14,67 +14,193 @@ abstract type AbstractSparseReverseMode <: AbstractReverseMode end
 abstract type AbstractSparseForwardMode <: AbstractForwardMode end
 abstract type AbstractSparseFiniteDifferences <: AbstractFiniteDifferencesMode end
 
+"""
+    AutoFiniteDiff{T1,T2,T3}
+
+Chooses [FiniteDiff.jl](https://github.com/JuliaDiff/FiniteDiff.jl).
+
+# Fields
+
+- `fdtype::T1 = Val(:forward)`
+- `fdjtype::T2 = fdtype`
+- `fdhtype::T3 = Val(:hcentral)`
+"""
 Base.@kwdef struct AutoFiniteDiff{T1, T2, T3} <: AbstractFiniteDifferencesMode
     fdtype::T1 = Val(:forward)
     fdjtype::T2 = fdtype
     fdhtype::T3 = Val(:hcentral)
 end
 
+"""
+    AutoFiniteDifferences{T}
+
+Chooses [FiniteDifferences.jl](https://github.com/JuliaDiff/FiniteDifferences.jl).
+
+# Fields
+
+- `fdm::T = nothing`
+"""
 Base.@kwdef struct AutoFiniteDifferences{T} <: AbstractFiniteDifferencesMode
     fdm::T = nothing
 end
 
-struct AutoForwardDiff{chunksize,T} <: AbstractForwardMode
+"""
+    AutoForwardDiff{chunksize,T}
+
+Chooses [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl).
+
+# Fields
+
+- `tag::T`
+"""
+struct AutoForwardDiff{chunksize, T} <: AbstractForwardMode
     tag::T
 end
 
+"""
+    AutoForwardDiff(; chunksize = nothing, tag = nothing)
+
+Constructor.
+"""
 function AutoForwardDiff(; chunksize = nothing, tag = nothing)
     AutoForwardDiff{chunksize, typeof(tag)}(tag)
 end
 
+"""
+    AutoPolyesterForwardDiff{chunksize}
+
+Chooses [PolyesterForwardDiff.jl](https://github.com/JuliaDiff/PolyesterForwardDiff.jl).
+"""
 struct AutoPolyesterForwardDiff{chunksize} <: AbstractForwardMode
 end
 
+"""
+    AutoPolyesterForwardDiff(; chunksize = nothing)
+
+Constructor.
+"""
 function AutoPolyesterForwardDiff(; chunksize = nothing)
     AutoPolyesterForwardDiff{chunksize}()
 end
 
+"""
+    AutoReverseDiff
+
+Chooses [ReverseDiff.jl](https://github.com/JuliaDiff/ReverseDiff.jl).
+
+# Fields
+
+- `compile::Bool = false`
+"""
 Base.@kwdef struct AutoReverseDiff <: AbstractReverseMode
     compile::Bool = false
 end
 
+"""
+    AutoZygote
+
+Chooses [Zygote.jl](https://github.com/FluxML/Zygote.jl).
+"""
 struct AutoZygote <: AbstractReverseMode end
+
+"""
+    AutoSparseZygote
+
+Chooses [Zygote.jl](https://github.com/FluxML/Zygote.jl) while exploiting sparsity.
+"""
 struct AutoSparseZygote <: AbstractSparseReverseMode end
 
+"""
+    AutoEnzyme{M}
+
+Chooses [Enzyme.jl](https://github.com/EnzymeAD/Enzyme.jl).
+
+# Fields
+
+- `mode::M = nothing`
+"""
 Base.@kwdef struct AutoEnzyme{M} <: AbstractADType
     mode::M = nothing
 end
 
+"""
+    AutoTracker
+
+Chooses [Tracker.jl](https://github.com/FluxML/Tracker.jl).
+"""
 struct AutoTracker <: AbstractReverseMode end
 
+"""
+    AutoModelingToolkit
+
+Chooses [ModelingToolkit.jl](https://github.com/SciML/ModelingToolkit.jl).
+
+# Fields
+
+- `obj_sparse::Bool = false`
+- `cons_sparse::Bool = false`
+"""
 Base.@kwdef struct AutoModelingToolkit <: AbstractSymbolicDifferentiationMode
     obj_sparse::Bool = false
     cons_sparse::Bool = false
 end
 
+"""
+    AutoSparseFiniteDiff
+
+Chooses [FiniteDiff.jl](https://github.com/JuliaDiff/FiniteDiff.jl) while exploiting sparsity.
+"""
 struct AutoSparseFiniteDiff <: AbstractSparseFiniteDifferences end
 
-struct AutoSparseForwardDiff{chunksize,T} <: AbstractSparseForwardMode
+"""
+    AutoSparseForwardDiff{chunksize,T}
+
+Chooses [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl) while exploiting sparsity.
+
+# Fields
+
+- `tag::T`
+"""
+struct AutoSparseForwardDiff{chunksize, T} <: AbstractSparseForwardMode
     tag::T
 end
 
+"""
+    AutoSparseForwardDiff(; chunksize = nothing, tag = nothing)
+
+Constructor.
+"""
 function AutoSparseForwardDiff(; chunksize = nothing, tag = nothing)
     AutoSparseForwardDiff{chunksize, typeof(tag)}(tag)
 end
 
+"""
+    AutoSparsePolyesterForwardDiff{chunksize}
+
+Chooses [PolyesterForwardDiff.jl](https://github.com/JuliaDiff/PolyesterForwardDiff.jl) while exploiting sparsity.
+"""
 struct AutoSparsePolyesterForwardDiff{chunksize} <: AbstractSparseForwardMode
 end
 
+"""
+    AutoSparsePolyesterForwardDiff(; chunksize = nothing)
+
+Constructor.
+"""
 function AutoSparsePolyesterForwardDiff(; chunksize = nothing)
     AutoSparsePolyesterForwardDiff{chunksize}()
 end
 
-Base.@kwdef struct AutoSparseReverseDiff <: AbstractSparseReverseMode 
+"""
+    AutoSparseReverseDiff
+
+Chooses [ReverseDiff.jl](https://github.com/JuliaDiff/ReverseDiff.jl) while exploiting sparsity.
+
+# Fields
+
+- `compile::Bool = false`
+"""
+Base.@kwdef struct AutoSparseReverseDiff <: AbstractSparseReverseMode
     compile::Bool = false
 end
 

--- a/src/ADTypes.jl
+++ b/src/ADTypes.jl
@@ -1,3 +1,8 @@
+"""
+    ADTypes.jl
+
+[ADTypes.jl](https://github.com/SciML/ADTypes.jl) is a common system for implementing multi-valued logic for choosing which automatic differentiation library to use.
+"""
 module ADTypes
 
 """


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

I'm not sure whether the lack of documentation is a bug or a feature. This is a pretty young and experimental package, so arguably we don't want to expose too much of the internals.

On the other hand it already has [18 registered direct dependents](https://juliahub.com/ui/Packages/General/ADTypes) and 492 indirect ones. I would assume those dependents use "the code as the documentation", which means everything is API by default. This PR makes the API more explicit and discoverable.
