### PR TITLE
Add docs website and revamp README

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,28 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    permissions:
+      contents: write
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - uses: julia-actions/cache@v1
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # If authenticating with SSH deploy key
+        run: julia --project=docs/ docs/make.jl

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/Manifest.toml
+Manifest.toml
+/docs/build/

--- a/README.md
+++ b/README.md
@@ -1,56 +1,32 @@
 # ADTypes.jl: Multi-Valued Logic for Automatic Differentiation Choices
 
-[![Build Status](https://github.com/Vaibhavdixit02/ADTypes.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/Vaibhavdixit02/ADTypes.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Docs stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://SciML.github.io/ADTypes.jl/stable/)
+[![Docs dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://SciML.github.io/ADTypes.jl/dev/)
+[![Build Status](https://github.com/SciML/ADTypes.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/SciML/ADTypes.jl/actions/workflows/CI.yml?query=branch%3Amain)
 
-ADTypes.jl is a common system for implementing multi-valued logic for choosing which
-automatic differentiation library to use.
+ADTypes.jl is a multi-valued logic system specifying the choice of an automatic differentiation (AD) library and its parameters.
 
-## Which libraries are supported?
+## Which AD libraries are supported?
 
-Just run the following code in a Julia REPL to find out:
+See the API reference in the documentation.
 
-```julia
-julia> using ADTypes
+## Why should packages adopt this standard?
 
-julia> names(ADTypes)
-16-element Vector{Symbol}:
- :ADTypes
- :AutoChainRules
- :AutoEnzyme
- :AutoFiniteDiff
- :AutoFiniteDifferences
- :AutoForwardDiff
- :AutoModelingToolkit
- :AutoPolyesterForwardDiff
- :AutoReverseDiff
- :AutoSparseFiniteDiff
- :AutoSparseForwardDiff
- :AutoSparsePolyesterForwardDiff
- :AutoSparseReverseDiff
- :AutoSparseZygote
- :AutoTracker
- :AutoZygote
-```
+A common practice is the use of a boolean keyword argument like `autodiff = true/false`.
+However, boolean logic is not precise enough for all the choices required.
+For instance, forward mode AD is implemented by both ForwardDiff and Enzyme, which makes `autodiff = true` ambiguous.
+Something like `ChooseForwardDiff()` is thus required, possibly with additional parameters depending on the library.
 
-Use the help mode of the Julia REPL to find out more about a specific library.
+The risk is that every package developer might develop their own version of `ChooseForwardDiff()`, which would ruin interoperability.
+This is why ADTypes.jl provides a single set of shared types for this task, as an extremely lightweight dependency.
+Wonder no more: `ADTypes.AutoForwardDiff()` is the way to go.
 
-## Why Should Packages Adopt This?
+## Why define types instead of enums?
 
-The current standard is to have a keyword argument with `autodiff = true` or `autodiff = false`.
-However, boolean logic is not sufficient to be able to do all of the choices that are
-required. For example for forward-mode AD there is ForwardDiff vs Enzyme, and thus `true`
-is ambgiuous. As libraries begin to support more and more of these autodiff mechanisms
-for their trade-offs, every library will have their own version of `ChooseForwardDiff()`
-etc. which would be a mess. Hence ADTypes.jl giving a single set of shared types for this.
-`ADTypes.AutoForwardDiff()` is the way to do it.
+If we used enums, they would not contain type-level information useful for dispatch.
+This is needed by many AD libraries to ensure type stability.
+Notably, the choice of config or cache type is different with each AD, so we must know statically which AD library is chosen.
 
-## Why are they types instead of enums? Or EnumX?
+## Why is this AD package missing?
 
-If they were enums then they would not be dispatch type-level information. This is needed
-for the internals of many of the packages to be type-stable because the choice of `config`
-type is different per package, i.e. what needs to be cached in order to use everything in
-a non-allocating manner.
-
-## My AD Package is Missing?
-
-Sure, give a PR to add it.
+Feel free to open a pull request adding it.

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "1.3"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,12 @@
+using Documenter
+using ADTypes
+
+makedocs(
+    sitename = "ADTypes",
+    format = Documenter.HTML(),
+    modules = [ADTypes]
+)
+
+deploydocs(
+    repo = "https://github.com/SciML/ADTypes.jl.git"
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,22 @@
+```@meta
+CurrentModule = ADTypes
+CollapsedDocStrings = true
+```
+
+# ADTypes.jl
+
+Documentation for [ADTypes.jl](https://github.com/SciML/ADTypes.jl/).
+
+## Public
+
+```@autodocs
+Modules = [ADTypes]
+Private = false
+```
+
+## Internal
+
+```@autodocs
+Modules = [ADTypes]
+Public = false
+```


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

- Add `docs` folder with `make.jl` and `src`
- Put the public and private API reference in `src/index.md`
- Add `Documentation.yml` workflow taken from https://documenter.juliadocs.org/dev/man/hosting/#GitHub-Actions
- Revamp README
- Add badges to README

I have also configured the SSH deploy keys in the repo with DocumenterTools, as described in https://documenter.juliadocs.org/dev/man/hosting/#travis-ssh
