### PR TITLE
Update TagBot workflow with write permissions

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -4,6 +4,22 @@ on:
     types:
       - created
   workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'


### PR DESCRIPTION
Workflow file taken from https://github.com/JuliaRegistries/TagBot?tab=readme-ov-file#setup

Since `GITHUB_TOKEN` is read-only by default on ADTypes.jl, it is necessary to elevate its permissions so that it can write in the repo contents (tags)