### PR TITLE
Lower compat bounds and downgrade tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,10 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: julia-actions/julia-downgrade-compat@v1
+        if: ${{ matrix.version == '1.10' }}
+        with:
+          skip: Pkg, TOML
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/Project.toml
+++ b/Project.toml
@@ -14,8 +14,8 @@ ADTypesChainRulesCoreExt = "ChainRulesCore"
 ADTypesEnzymeCoreExt = "EnzymeCore"
 
 [compat]
-ChainRulesCore = "1.23.0"
-EnzymeCore = "0.7.2"
+ChainRulesCore = "1.0.2"
+EnzymeCore = "0.5.3,0.6,0.7"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

The compat bounds for ChainRulesCore and EnzymeCore were the most recent ones. I relaxed them to versions where I am sure that the necessary objects already exist, and added a downgrade compat test on Julia 1.10
