### PR TITLE
Support Julia 1.6 (again)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest
@@ -31,7 +31,7 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/julia-downgrade-compat@v1
-        if: ${{ matrix.version == '1.10' }}
+        if: ${{ matrix.version == '1.6' }}
         with:
           skip: Pkg, TOML
       - uses: julia-actions/cache@v1

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,11 @@ uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = [
     "Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors",
 ]
-version = "1.0.0"
+version = "1.1.0"
+
+[deps]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
 
 [weakdeps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -16,7 +20,7 @@ ADTypesEnzymeCoreExt = "EnzymeCore"
 [compat]
 ChainRulesCore = "1.0.2"
 EnzymeCore = "0.5.3,0.6,0.7"
-julia = "1.10"
+julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,11 +52,13 @@ end
 ## Tests
 
 @testset verbose=true "ADTypes.jl" begin
-    @testset "Aqua.jl" begin
-        Aqua.test_all(ADTypes; deps_compat = (check_extras = false,))
-    end
-    @testset "JET.jl" begin
-        JET.test_package(ADTypes, target_defined_modules = true)
+    if VERSION >= v"1.10"
+        @testset "Aqua.jl" begin
+            Aqua.test_all(ADTypes; deps_compat = (check_extras = false,))
+        end
+        @testset "JET.jl" begin
+            JET.test_package(ADTypes, target_defined_modules = true)
+        end
     end
     @testset "Dense" begin
         include("dense.jl")


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This PR makes EnzymeCoreExt and ChainRulesExt unconditional dependencies for Julia <1.9, thus allowing support for older Julia versions.
We initially decided against it in https://github.com/SciML/ADTypes.jl/pull/40#issuecomment-2055319884, but as shown by #47 some users would like this feature. It is zero-cost for us, so why not?
