### PR TITLE
Revert "Support Julia 1.6 (again)"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.10'
           - '1'
         os:
           - ubuntu-latest
@@ -31,7 +31,7 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/julia-downgrade-compat@v1
-        if: ${{ matrix.version == '1.6' }}
+        if: ${{ matrix.version == '1.10' }}
         with:
           skip: Pkg, TOML
       - uses: julia-actions/cache@v1

--- a/Project.toml
+++ b/Project.toml
@@ -3,11 +3,7 @@ uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = [
     "Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors",
 ]
-version = "1.1.0"
-
-[deps]
-ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+version = "1.0.0"
 
 [weakdeps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -20,7 +16,7 @@ ADTypesEnzymeCoreExt = "EnzymeCore"
 [compat]
 ChainRulesCore = "1.0.2"
 EnzymeCore = "0.5.3,0.6,0.7"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/ADTypes.jl
+++ b/src/ADTypes.jl
@@ -21,11 +21,6 @@ include("dense.jl")
 include("sparse.jl")
 include("legacy.jl")
 
-if !isdefined(Base, :get_extension)
-    include("../ext/ADTypesChainRulesCoreExt.jl")
-    include("../ext/ADTypesEnzymeCoreExt.jl")
-end
-
 export AbstractADType
 
 export AutoChainRules,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,13 +52,11 @@ end
 ## Tests
 
 @testset verbose=true "ADTypes.jl" begin
-    if VERSION >= v"1.10"
-        @testset "Aqua.jl" begin
-            Aqua.test_all(ADTypes; deps_compat = (check_extras = false,))
-        end
-        @testset "JET.jl" begin
-            JET.test_package(ADTypes, target_defined_modules = true)
-        end
+    @testset "Aqua.jl" begin
+        Aqua.test_all(ADTypes; deps_compat = (check_extras = false,))
+    end
+    @testset "JET.jl" begin
+        JET.test_package(ADTypes, target_defined_modules = true)
     end
     @testset "Dense" begin
         include("dense.jl")


### PR DESCRIPTION
Reverts SciML/ADTypes.jl#48

If @ChrisRackauckas says SciML is ready to drop Julia below 1.10, then let's lean into it