### PR TITLE
Add AutoModelingToolkit to deprecations

### DIFF
--- a/src/ADTypes.jl
+++ b/src/ADTypes.jl
@@ -39,13 +39,6 @@ export AutoChainRules,
 
 export AutoSparse
 
-# legacy
-
-export AutoSparseFastDifferentiation,
-       AutoSparseFiniteDiff,
-       AutoSparseForwardDiff,
-       AutoSparsePolyesterForwardDiff,
-       AutoSparseReverseDiff,
-       AutoSparseZygote
+# legacy exports are taken care of by @deprecated
 
 end

--- a/src/legacy.jl
+++ b/src/legacy.jl
@@ -10,3 +10,5 @@
 @deprecate AutoSparseReverseDiff(; kwargs...) AutoSparse(AutoReverseDiff(; kwargs...))
 
 @deprecate AutoSparseZygote() AutoSparse(AutoZygote())
+
+@deprecate AutoModelingToolkit(; kwargs...) AutoSparse(AutoSymbolics())

--- a/test/legacy.jl
+++ b/test/legacy.jl
@@ -1,11 +1,18 @@
+@testset "AutoModelingToolkig" begin
+    ad = @test_deprecated AutoModelingToolkit()
+    @test ad isa AbstractADType
+    @test ad isa AutoSparse
+    @test dense_ad(ad) isa AutoSymbolics
+end
+
 @testset "AutoSparseFastDifferentiation" begin
-    ad = AutoSparseFastDifferentiation()
+    ad = @test_deprecated AutoSparseFastDifferentiation()
     @test ad isa AbstractADType
     @test dense_ad(ad) isa AutoFastDifferentiation
 end
 
 @testset "AutoSparseFiniteDiff" begin
-    ad = AutoSparseFiniteDiff()
+    ad = @test_deprecated AutoSparseFiniteDiff()
     @test ad isa AbstractADType
     @test dense_ad(ad) isa AutoFiniteDiff
     @test dense_ad(ad).fdtype === Val(:forward)
@@ -14,30 +21,31 @@ end
 end
 
 @testset "AutoSparseForwardDiff" begin
-    ad = AutoSparseForwardDiff()
+    ad = @test_deprecated AutoSparseForwardDiff()
     @test ad isa AbstractADType
     @test dense_ad(ad) isa AutoForwardDiff{nothing, Nothing}
 
-    ad = AutoSparseForwardDiff(; chunksize = 10, tag = CustomTag())
+    ad = @test_deprecated AutoSparseForwardDiff(; chunksize = 10, tag = CustomTag())
     @test ad isa AbstractADType
     @test dense_ad(ad) isa AutoForwardDiff{10, CustomTag}
 end
 
 @testset "AutoSparsePolyesterForwardDiff" begin
-    ad = AutoSparsePolyesterForwardDiff(; chunksize = 10, tag = CustomTag())
+    ad = @test_deprecated AutoSparsePolyesterForwardDiff(;
+        chunksize = 10, tag = CustomTag())
     @test ad isa AbstractADType
     @test dense_ad(ad) isa AutoPolyesterForwardDiff{10, CustomTag}
 end
 
 @testset "AutoSparseReverseDiff" begin
-    ad = AutoSparseReverseDiff(; compile = true)
+    ad = @test_deprecated AutoSparseReverseDiff(; compile = true)
     @test ad isa AbstractADType
     @test dense_ad(ad) isa AutoReverseDiff
     @test dense_ad(ad).compile
 end
 
 @testset "AutoSparseZygote" begin
-    ad = AutoSparseZygote()
+    ad = @test_deprecated AutoSparseZygote()
     @test ad isa AbstractADType
     @test dense_ad(ad) isa AutoZygote
 end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
