### PR TITLE
Support Julia 1.6 for Turing and others

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest
@@ -31,7 +31,7 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/julia-downgrade-compat@v1
-        if: ${{ matrix.version == '1.10' }}
+        if: ${{ matrix.version == '1.6' }}
         with:
           skip: Pkg, TOML
       - uses: julia-actions/cache@v1

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = [
     "Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors",
 ]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,10 @@ authors = [
 ]
 version = "1.0.0"
 
+[deps]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+
 [weakdeps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
@@ -16,7 +20,7 @@ ADTypesEnzymeCoreExt = "EnzymeCore"
 [compat]
 ChainRulesCore = "1.0.2"
 EnzymeCore = "0.5.3,0.6,0.7"
-julia = "1.10"
+julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/ADTypes.jl
+++ b/src/ADTypes.jl
@@ -21,6 +21,11 @@ include("dense.jl")
 include("sparse.jl")
 include("legacy.jl")
 
+if !isdefined(Base, :get_extension)
+    include("../ext/ADTypesChainRulesCoreExt.jl")
+    include("../ext/ADTypesEnzymeCoreExt.jl")
+end
+
 export AbstractADType
 
 export AutoChainRules,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,11 +52,13 @@ end
 ## Tests
 
 @testset verbose=true "ADTypes.jl" begin
-    @testset "Aqua.jl" begin
-        Aqua.test_all(ADTypes; deps_compat = (check_extras = false,))
-    end
-    @testset "JET.jl" begin
-        JET.test_package(ADTypes, target_defined_modules = true)
+    if VERSION >= v"1.10"
+        @testset "Aqua.jl" begin
+            Aqua.test_all(ADTypes; deps_compat = (check_extras = false,))
+        end
+        @testset "JET.jl" begin
+            JET.test_package(ADTypes, target_defined_modules = true)
+        end
     end
     @testset "Dense" begin
         include("dense.jl")


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Judging by the discussion with @devmotion in https://github.com/tpapp/LogDensityProblemsAD.jl/pull/29#discussion_r1586798822, support for 1.6 is important in other parts of the ecosystem, even though SciML is willing to drop it sooner. The maintenance burden is very minimal in ADTypes.jl, so I'm adding it again.

Related discussions:

- https://github.com/SciML/ADTypes.jl/pull/40#issuecomment-2056572382
- https://github.com/SciML/ADTypes.jl/pull/48#issuecomment-2078489971