### PR TITLE
Add safe mode

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = [
     "Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors",
 ]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -172,8 +172,14 @@ mode(::AutoSymbolics) = SymbolicMode()
 Struct used to select the [Tapir.jl](https://github.com/withbayes/Tapir.jl) backend for automatic differentiation.
 
 Exported from [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+
+# Keyword Arguments
+
+- `safe_mode::Bool`: whether to run additional checks to catch errors early. On by default. Turn off to maximise performance if your code runs correctly.
 """
-struct AutoTapir <: AbstractADType end
+Base.@kwdef struct AutoTapir <: AbstractADType
+    safe_mode::Bool = true
+end
 
 mode(::AutoTapir) = ReverseMode()
 

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -138,6 +138,7 @@ end
     @test ad isa AbstractADType
     @test ad isa AutoTapir
     @test mode(ad) isa ReverseMode
+    @test ad.safe_mode == true
 end
 
 @testset "AutoTracker" begin

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -138,7 +138,10 @@ end
     @test ad isa AbstractADType
     @test ad isa AutoTapir
     @test mode(ad) isa ReverseMode
-    @test ad.safe_mode == true
+    @test ad.safe_mode
+    
+    ad = AutoTapir(; safe_mode=false)
+    @test !ad.safe_mode
 end
 
 @testset "AutoTracker" begin


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Tapir.jl now has a "safe mode", in which lots of additional type checking is performed, in addition to some value checks. I would like to enable it by default (I'll be adding `@info` calls on the Tapir end to make it clear to users that they're using safe mode). This is to ensure that users are aware of this feature, which often makes debugging a lot easier, and can pick up on issues before they propagate to some arbitrary point further on in the code.

Provided that people are happy with this, if someone could advise on the appropriate version bump for this package I would appreciate it.
