### PR TITLE
Restore full API in docstrings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = [
     "Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors",
 ]
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1,11 +1,15 @@
 """
-    AutoChainRules(; ruleconfig)
+    AutoChainRules{RC}
 
 Struct used to select an automatic differentiation backend based on [ChainRulesCore.jl](https://github.com/JuliaDiff/ChainRulesCore.jl) (see the list [here](https://juliadiff.org/ChainRulesCore.jl/stable/index.html#ChainRules-roll-out-status)).
 
-Exported from [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
 
-# Keyword Arguments
+# Constructors
+
+    AutoChainRules(; ruleconfig)
+
+# Fields
 
 - `ruleconfig::RC`: a [`ChainRulesCore.RuleConfig`](https://juliadiff.org/ChainRulesCore.jl/stable/rule_author/superpowers/ruleconfig.html) object.
 """
@@ -16,24 +20,32 @@ end
 mode(::AutoChainRules) = ForwardOrReverseMode()  # specialized in the extension
 
 """
-    AutoDiffractor()
+    AutoDiffractor
 
 Struct used to select the [Diffractor.jl](https://github.com/JuliaDiff/Diffractor.jl) backend for automatic differentiation.
 
-Exported from [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+
+# Constructors
+
+    AutoDiffractor()
 """
 struct AutoDiffractor <: AbstractADType end
 
 mode(::AutoDiffractor) = ForwardOrReverseMode()
 
 """
+    AutoEnzyme{M}
+    
+Struct used to select the [Enzyme.jl](https://github.com/EnzymeAD/Enzyme.jl) backend for automatic differentiation.
+    
+Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+    
+# Constructors
+
     AutoEnzyme(; mode=nothing)
 
-Struct used to select the [Enzyme.jl](https://github.com/EnzymeAD/Enzyme.jl) backend for automatic differentiation.
-
-Exported from [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
-
-# Keyword Arguments
+# Fields
 
 - `mode::M`: can be either 
   - an object subtyping `EnzymeCore.Mode` (like `EnzymeCore.Forward` or `EnzymeCore.Reverse`) if a specific mode is required
@@ -46,24 +58,32 @@ end
 mode(::AutoEnzyme) = ForwardOrReverseMode()  # specialized in the extension
 
 """
-    AutoFastDifferentiation()
+    AutoFastDifferentiation
 
 Struct used to select the [FastDifferentiation.jl](https://github.com/brianguenter/FastDifferentiation.jl) backend for automatic differentiation.
 
-Exported from [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+
+# Constructors
+
+    AutoFastDifferentiation()
 """
 struct AutoFastDifferentiation <: AbstractADType end
 
 mode(::AutoFastDifferentiation) = SymbolicMode()
 
 """
-    AutoFiniteDiff(; fdtype=Val(:forward), fdjtype=fdtype, fdhtype=Val(:hcentral))
+    AutoFiniteDiff{T1,T2,T3}
 
 Struct used to select the [FiniteDiff.jl](https://github.com/JuliaDiff/FiniteDiff.jl) backend for automatic differentiation.
 
-Exported from [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
 
-# Keyword Arguments
+# Constructors
+
+    AutoFiniteDiff(; fdtype=Val(:forward), fdjtype=fdtype, fdhtype=Val(:hcentral))
+
+# Fields
 
 - `fdtype::T1`: finite difference type
 - `fdjtype::T2`: finite difference type for the Jacobian
@@ -78,13 +98,17 @@ end
 mode(::AutoFiniteDiff) = ForwardMode()
 
 """
-    AutoFiniteDifferences(; fdm)
+    AutoFiniteDifferences{T}
 
 Struct used to select the [FiniteDifferences.jl](https://github.com/JuliaDiff/FiniteDifferences.jl) backend for automatic differentiation.
 
-Exported from [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
 
-# Keyword Arguments
+# Constructors
+
+    AutoFiniteDifferences(; fdm)
+
+# Fields
 
 - `fdm::T`: a [`FiniteDifferenceMethod`](https://juliadiff.org/FiniteDifferences.jl/stable/pages/api/#FiniteDifferences.FiniteDifferenceMethod)
 """
@@ -95,15 +119,22 @@ end
 mode(::AutoFiniteDifferences) = ForwardMode()
 
 """
-    AutoForwardDiff(; chunksize=nothing, tag=nothing)
+    AutoForwardDiff{chunksize,T}
 
 Struct used to select the [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl) backend for automatic differentiation.
 
-Exported from [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
 
-# Keyword Arguments
+# Constructors
+
+    AutoForwardDiff(; chunksize=nothing, tag=nothing)
+
+# Type parameters
 
 - `chunksize`: the preferred [chunk size](https://juliadiff.org/ForwardDiff.jl/stable/user/advanced/#Configuring-Chunk-Size) to evaluate several derivatives at once
+
+# Fields
+
 - `tag::T`: a [custom tag](https://juliadiff.org/ForwardDiff.jl/release-0.10/user/advanced.html#Custom-tags-and-tag-checking-1) to handle nested differentiation calls (usually not necessary)
 """
 struct AutoForwardDiff{chunksize, T} <: AbstractADType
@@ -117,15 +148,22 @@ end
 mode(::AutoForwardDiff) = ForwardMode()
 
 """
+    AutoPolyesterForwardDiff{chunksize,T}
+    
+Struct used to select the [PolyesterForwardDiff.jl](https://github.com/JuliaDiff/PolyesterForwardDiff.jl) backend for automatic differentiation.
+    
+Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+    
+# Constructors
+    
     AutoPolyesterForwardDiff(; chunksize=nothing, tag=nothing)
 
-Struct used to select the [PolyesterForwardDiff.jl](https://github.com/JuliaDiff/PolyesterForwardDiff.jl) backend for automatic differentiation.
-
-Exported from [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
-
-# Keyword Arguments
+# Type parameters
 
 - `chunksize`: the preferred [chunk size](https://juliadiff.org/ForwardDiff.jl/stable/user/advanced/#Configuring-Chunk-Size) to evaluate several derivatives at once
+
+# Fields
+
 - `tag::T`: a [custom tag](https://juliadiff.org/ForwardDiff.jl/release-0.10/user/advanced.html#Custom-tags-and-tag-checking-1) to handle nested differentiation calls (usually not necessary)
 """
 struct AutoPolyesterForwardDiff{chunksize, T} <: AbstractADType
@@ -139,13 +177,17 @@ end
 mode(::AutoPolyesterForwardDiff) = ForwardMode()
 
 """
-    AutoReverseDiff(; compile=false)
+    AutoReverseDiff
 
 Struct used to select the [ReverseDiff.jl](https://github.com/JuliaDiff/ReverseDiff.jl) backend for automatic differentiation.
 
-Exported from [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
 
-# Keyword Arguments
+# Constructors
+
+    AutoReverseDiff(; compile=false)
+
+# Fields
 
 - `compile::Bool`: whether to [compile the tape](https://juliadiff.org/ReverseDiff.jl/api/#ReverseDiff.compile) prior to differentiation
 """
@@ -156,24 +198,32 @@ end
 mode(::AutoReverseDiff) = ReverseMode()
 
 """
-    AutoSymbolics()
+    AutoSymbolics
 
 Struct used to select the [Symbolics.jl](https://github.com/JuliaSymbolics/Symbolics.jl) backend for automatic differentiation.
 
-Exported from [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+
+# Constructors
+
+    AutoSymbolics()
 """
 struct AutoSymbolics <: AbstractADType end
 
 mode(::AutoSymbolics) = SymbolicMode()
 
 """
-    AutoTapir()
+    AutoTapir
 
 Struct used to select the [Tapir.jl](https://github.com/withbayes/Tapir.jl) backend for automatic differentiation.
 
-Exported from [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
 
-# Keyword Arguments
+# Constructors
+
+    AutoTapir(; safe_mode=true)
+
+# Fields
 
 - `safe_mode::Bool`: whether to run additional checks to catch errors early. On by default. Turn off to maximise performance if your code runs correctly.
 """
@@ -188,9 +238,9 @@ mode(::AutoTapir) = ReverseMode()
 
 Struct used to select the [Tracker.jl](https://github.com/FluxML/Tracker.jl) backend for automatic differentiation.
 
-Exported from [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
 
-# Constructor
+# Constructors
 
     AutoTracker()
 """
@@ -199,11 +249,15 @@ struct AutoTracker <: AbstractADType end
 mode(::AutoTracker) = ReverseMode()
 
 """
-    AutoZygote()
+    AutoZygote
 
 Struct used to select the [Zygote.jl](https://github.com/FluxML/Zygote.jl) backend for automatic differentiation.
 
-Exported from [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
+
+# Constructors
+
+    AutoZygote()
 """
 struct AutoZygote <: AbstractADType end
 

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -36,7 +36,7 @@ mode(::AutoDiffractor) = ForwardOrReverseMode()
 
 """
     AutoEnzyme{M}
-    
+
 Struct used to select the [Enzyme.jl](https://github.com/EnzymeAD/Enzyme.jl) backend for automatic differentiation.
     
 Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Fix #56 by reinstating full docstrings with type parameters and fields
