### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -6,7 +6,8 @@ on:
       - main
     tags: '*'
   pull_request:
-
+  schedule:
+    - cron: '53 20 * * 5'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Downgrade
 on:
   pull_request:
     branches:
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     env:
-      GROUP: ${{ matrix.group }}
+      GROUP: ${{ matrix.group }}    
     strategy:
       fail-fast: false
       matrix:
@@ -33,6 +33,9 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
+      - uses: julia-actions/julia-downgrade-compat@v1
+        with:
+          skip: Pkg,TOML
       - uses: julia-actions/cache@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,11 +43,3 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           GROUP: ${{ matrix.group }}
-        with:
-          depwarn: error
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v4
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ ADTypesEnzymeCoreExt = "EnzymeCore"
 [compat]
 ChainRulesCore = "1.0.2"
 EnzymeCore = "0.5.3,0.6,0.7"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,13 +52,11 @@ end
 ## Tests
 
 @testset verbose=true "ADTypes.jl" begin
-    if VERSION >= v"1.10"
-        @testset "Aqua.jl" begin
-            Aqua.test_all(ADTypes; deps_compat = (check_extras = false,))
-        end
-        @testset "JET.jl" begin
-            JET.test_package(ADTypes, target_defined_modules = true)
-        end
+    @testset "Aqua.jl" begin
+        Aqua.test_all(ADTypes; deps_compat = (check_extras = false,))
+    end
+    @testset "JET.jl" begin
+        JET.test_package(ADTypes, target_defined_modules = true)
     end
     @testset "Dense" begin
         include("dense.jl")


### PR DESCRIPTION
Makes CI more uniform with rest of SciML.
Removes testing for 1.6, since rest of SciML dropped support.
Activates errors on deprecation. Not sure what to do with the tests in the legacy file, since these will now error.