### PR TITLE
Add Symbol -> AbstractADType mapping

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = [
     "Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors",
 ]
-version = "1.3.1"
+version = "1.4.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = [
     "Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors",
 ]
-version = "1.3.0"
+version = "1.3.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -92,3 +92,9 @@ ADTypes.ForwardOrReverseMode
 ADTypes.ReverseMode
 ADTypes.SymbolicMode
 ```
+
+## Miscellaneous
+
+```@docs
+ADTypes.Auto
+```

--- a/src/ADTypes.jl
+++ b/src/ADTypes.jl
@@ -20,6 +20,7 @@ include("mode.jl")
 include("dense.jl")
 include("sparse.jl")
 include("legacy.jl")
+include("symbols.jl")
 
 if !isdefined(Base, :get_extension)
     include("../ext/ADTypesChainRulesCoreExt.jl")

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -24,6 +24,6 @@ Auto(package::Symbol, args...; kws...) = Auto(Val(package), args...; kws...)
 for backend in (:ChainRules, :Diffractor, :Enzyme, :FastDifferentiation,
                 :FiniteDiff, :FiniteDifferences, :ForwardDiff, :PolyesterForwardDiff,
                 :ReverseDiff, :Symbolics, :Tapir, :Tracker, :Zygote)
-    @eval Auto(::Val{$backend}, args...; kws...) = $(Symbol(:Auto, backend))(args...; kws...)
+    @eval Auto(::Val{$(QuoteNode(backend))}, args...; kws...) = $(Symbol(:Auto, backend))(args...; kws...)
 end
 

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -19,24 +19,11 @@ backend = ADTypes.Auto(:Zygote)
 ADTypes.AutoZygote()
 ```
 """
-Auto(package::Symbol) = Auto(Val(package))
+Auto(package::Symbol, args...; kws...) = Auto(Val(package), args...; kws...)
 
-Auto(::Val{:Diffractor}) = AutoDiffractor()
-Auto(::Val{:Enzyme}) = AutoEnzyme()
-Auto(::Val{:FastDifferentiation}) = AutoFastDifferentiation()
-Auto(::Val{:FiniteDiff}) = AutoFiniteDiff()
-Auto(::Val{:ForwardDiff}) = AutoForwardDiff()
-Auto(::Val{:PolyesterForwardDiff}) = AutoPolyesterForwardDiff()
-Auto(::Val{:ReverseDiff}) = AutoReverseDiff()
-Auto(::Val{:Symbolics}) = AutoSymbolics()
-Auto(::Val{:Tapir}) = AutoTapir()
-Auto(::Val{:Tracker}) = AutoTracker()
-Auto(::Val{:Zygote}) = AutoZygote()
-
-function Auto(::Val{:ChainRules})
-    throw(ArgumentError("ChainRules backend has mandatory arguments"))
+for backend in (:ChainRules, :Diffractor, :Enzyme, :FastDifferentiation,
+                :FiniteDiff, :FiniteDifferences, :ForwardDiff, :PolyesterForwardDiff,
+                :ReverseDiff, :Symbolics, :Tapir, :Tracker, :Zygote)
+    @eval Auto(::Val{$backend}, args...; kws...) = $(Symbol(:Auto, backend))(args...; kws...)
 end
 
-function Auto(::Val{:FiniteDifferences})
-    throw(ArgumentError("FiniteDifferences backend has mandatory arguments"))
-end

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -1,0 +1,42 @@
+"""
+    ADTypes.Auto(package::Symbol)
+
+A shortcut that converts an AD package name into an instance of [`AbstractADType`](@ref), with all parameters set to their default values.
+
+!!! warning
+
+    This function is type-unstable by design and might lead to suboptimal performance.
+    In most cases, you should never need it: use the individual backend types directly.
+
+# Example
+
+```jldoctest
+import ADTypes
+backend = ADTypes.Auto(:Zygote)
+
+# output
+
+ADTypes.AutoZygote()
+```
+"""
+Auto(package::Symbol) = Auto(Val(package))
+
+Auto(::Val{:Diffractor}) = AutoDiffractor()
+Auto(::Val{:Enzyme}) = AutoEnzyme()
+Auto(::Val{:FastDifferentiation}) = AutoFastDifferentiation()
+Auto(::Val{:FiniteDiff}) = AutoFiniteDiff()
+Auto(::Val{:ForwardDiff}) = AutoForwardDiff()
+Auto(::Val{:PolyesterForwardDiff}) = AutoPolyesterForwardDiff()
+Auto(::Val{:ReverseDiff}) = AutoReverseDiff()
+Auto(::Val{:Symbolics}) = AutoSymbolics()
+Auto(::Val{:Tapir}) = AutoTapir()
+Auto(::Val{:Tracker}) = AutoTracker()
+Auto(::Val{:Zygote}) = AutoZygote()
+
+function Auto(::Val{:ChainRules})
+    throw(ArgumentError("ChainRules backend has mandatory arguments"))
+end
+
+function Auto(::Val{:FiniteDifferences})
+    throw(ArgumentError("FiniteDifferences backend has mandatory arguments"))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,9 @@ end
     @testset "Sparse" begin
         include("sparse.jl")
     end
+    @testset "Symbols" begin
+        include("symbols.jl")
+    end
     @testset "Legacy" begin
         include("legacy.jl")
     end

--- a/test/symbols.jl
+++ b/test/symbols.jl
@@ -14,3 +14,7 @@ using Test
 @test ADTypes.Auto(:Tapir) isa AutoTapir
 @test ADTypes.Auto(:Tracker) isa AutoTracker
 @test ADTypes.Auto(:Zygote) isa AutoZygote
+
+@test_throws MethodError ADTypes.Auto(:ThisPackageDoesNotExist)
+@test_throws UndefKeywordError ADTypes.Auto(:ChainRules)
+@test_throws UndefKeywordError ADTypes.Auto(:FiniteDifferences)

--- a/test/symbols.jl
+++ b/test/symbols.jl
@@ -1,10 +1,12 @@
 using ADTypes
 using Test
 
+@test ADTypes.Auto(:ChainRules, 1) isa AutoChainRules{Int64}
 @test ADTypes.Auto(:Diffractor) isa AutoDiffractor
 @test ADTypes.Auto(:Enzyme) isa AutoEnzyme
 @test ADTypes.Auto(:FastDifferentiation) isa AutoFastDifferentiation
 @test ADTypes.Auto(:FiniteDiff) isa AutoFiniteDiff
+@test ADTypes.Auto(:FiniteDifferences, 1.0) isa AutoFiniteDifferences{Float64}
 @test ADTypes.Auto(:ForwardDiff) isa AutoForwardDiff
 @test ADTypes.Auto(:PolyesterForwardDiff) isa AutoPolyesterForwardDiff
 @test ADTypes.Auto(:ReverseDiff) isa AutoReverseDiff
@@ -12,6 +14,3 @@ using Test
 @test ADTypes.Auto(:Tapir) isa AutoTapir
 @test ADTypes.Auto(:Tracker) isa AutoTracker
 @test ADTypes.Auto(:Zygote) isa AutoZygote
-
-@test_throws ArgumentError ADTypes.Auto(:ChainRules)
-@test_throws ArgumentError ADTypes.Auto(:FiniteDifferences)

--- a/test/symbols.jl
+++ b/test/symbols.jl
@@ -1,0 +1,17 @@
+using ADTypes
+using Test
+
+@test ADTypes.Auto(:Diffractor) isa AutoDiffractor
+@test ADTypes.Auto(:Enzyme) isa AutoEnzyme
+@test ADTypes.Auto(:FastDifferentiation) isa AutoFastDifferentiation
+@test ADTypes.Auto(:FiniteDiff) isa AutoFiniteDiff
+@test ADTypes.Auto(:ForwardDiff) isa AutoForwardDiff
+@test ADTypes.Auto(:PolyesterForwardDiff) isa AutoPolyesterForwardDiff
+@test ADTypes.Auto(:ReverseDiff) isa AutoReverseDiff
+@test ADTypes.Auto(:Symbolics) isa AutoSymbolics
+@test ADTypes.Auto(:Tapir) isa AutoTapir
+@test ADTypes.Auto(:Tracker) isa AutoTracker
+@test ADTypes.Auto(:Zygote) isa AutoZygote
+
+@test_throws ArgumentError ADTypes.Auto(:ChainRules)
+@test_throws ArgumentError ADTypes.Auto(:FiniteDifferences)


### PR DESCRIPTION
In https://github.com/gdalle/DifferentiationInterface.jl/issues/319, @MilesCranmer proposed a mapping from package `Symbol`s to `AbstractADType`s. While this mapping is not strictly necessary, it makes things easier for interfacing with Python. Here's an experimental PR doing just that, let's see what people think.

>[!WARNING]
>I don't want to encourage the use of `Symbol`s, since ADTypes.jl is precisely there to avoid their shortcomings. Hence the strongly-worded docstring.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API