### PR TITLE
Fix pretty printing and ReverseDiff constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = [
     "Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors",
 ]
-version = "1.5.1"
+version = "1.5.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -20,7 +20,7 @@ end
 mode(::AutoChainRules) = ForwardOrReverseMode()  # specialized in the extension
 
 function Base.show(io::IO, backend::AutoChainRules)
-    print(io, "AutoChainRules(ruleconfig=$(repr(backend.ruleconfig, context=io)))")
+    print(io, AutoChainRules, "(ruleconfig=", repr(backend.ruleconfig; context = io), ")")
 end
 
 """
@@ -63,11 +63,9 @@ end
 mode(::AutoEnzyme) = ForwardOrReverseMode()  # specialized in the extension
 
 function Base.show(io::IO, backend::AutoEnzyme)
-    if isnothing(backend.mode)
-        print(io, "AutoEnzyme()")
-    else
-        print(io, "AutoEnzyme(mode=$(repr(backend.mode, context=io)))")
-    end
+    print(io, AutoEnzyme, "(")
+    !isnothing(backend.mode) && print(io, "mode=", repr(backend.mode; context = io))
+    print(io, ")")
 end
 
 """
@@ -111,21 +109,14 @@ end
 mode(::AutoFiniteDiff) = ForwardMode()
 
 function Base.show(io::IO, backend::AutoFiniteDiff)
-    s = "AutoFiniteDiff("
-    if backend.fdtype != Val(:forward)
-        s *= "fdtype=$(repr(backend.fdtype, context=io)), "
-    end
-    if backend.fdjtype != backend.fdtype
-        s *= "fdjtype=$(repr(backend.fdjtype, context=io)), "
-    end
-    if backend.fdhtype != Val(:hcentral)
-        s *= "fdhtype=$(repr(backend.fdhtype, context=io)), "
-    end
-    if endswith(s, ", ")
-        s = s[1:(end - 2)]
-    end
-    s *= ")"
-    print(io, s)
+    print(io, AutoFiniteDiff, "(")
+    backend.fdtype != Val(:forward) &&
+        print(io, "fdtype=", repr(backend.fdtype; context = io), ",")
+    backend.fdjtype != backend.fdtype &&
+        print(io, "fdjtype=", repr(backend.fdjtype; context = io), ",")
+    backend.fdhtype != Val(:hcentral) &&
+        print(io, "fdhtype=", repr(backend.fdhtype; context = io), ",")
+    print(io, ")")
 end
 
 """
@@ -150,7 +141,7 @@ end
 mode(::AutoFiniteDifferences) = ForwardMode()
 
 function Base.show(io::IO, backend::AutoFiniteDifferences)
-    print(io, "AutoFiniteDifferences(fdm=$(repr(backend.fdm, context=io)))")
+    print(io, AutoFiniteDifferences, "(fdm=", repr(backend.fdm; context = io), ")")
 end
 
 """
@@ -183,18 +174,10 @@ end
 mode(::AutoForwardDiff) = ForwardMode()
 
 function Base.show(io::IO, backend::AutoForwardDiff{chunksize}) where {chunksize}
-    s = "AutoForwardDiff("
-    if chunksize !== nothing
-        s *= "chunksize=$chunksize, "
-    end
-    if backend.tag !== nothing
-        s *= "tag=$(repr(backend.tag, context=io)), "
-    end
-    if endswith(s, ", ")
-        s = s[1:(end - 2)]
-    end
-    s *= ")"
-    print(io, s)
+    print(io, AutoForwardDiff, "(")
+    chunksize !== nothing && print(io, "chunksize=", repr(chunksize; context = io), ",")
+    backend.tag !== nothing && print(io, "tag=", repr(backend.tag; context = io), ",")
+    print(io, ")")
 end
 
 """
@@ -227,18 +210,10 @@ end
 mode(::AutoPolyesterForwardDiff) = ForwardMode()
 
 function Base.show(io::IO, backend::AutoPolyesterForwardDiff{chunksize}) where {chunksize}
-    s = "AutoPolyesterForwardDiff("
-    if chunksize !== nothing
-        s *= "chunksize=$chunksize, "
-    end
-    if backend.tag !== nothing
-        s *= "tag=$(repr(backend.tag, context=io)), "
-    end
-    if endswith(s, ", ")
-        s = s[1:(end - 2)]
-    end
-    s *= ")"
-    print(io, s)
+    print(io, AutoPolyesterForwardDiff, "(")
+    chunksize !== nothing && print(io, "chunksize=", repr(chunksize; context = io), ",")
+    backend.tag !== nothing && print(io, "tag=", repr(backend.tag; context = io), ",")
+    print(io, ")")
 end
 
 """
@@ -277,11 +252,9 @@ end
 mode(::AutoReverseDiff) = ReverseMode()
 
 function Base.show(io::IO, ::AutoReverseDiff{compile}) where {compile}
-    if !compile
-        print(io, "AutoReverseDiff()")
-    else
-        print(io, "AutoReverseDiff(compile=true)")
-    end
+    print(io, AutoReverseDiff, "(")
+    compile && print(io, "compile=true")
+    print(io, ")")
 end
 
 """
@@ -321,11 +294,9 @@ end
 mode(::AutoTapir) = ReverseMode()
 
 function Base.show(io::IO, backend::AutoTapir)
-    if backend.safe_mode
-        print(io, "AutoTapir()")
-    else
-        print(io, "AutoTapir(safe_mode=false)")
-    end
+    print(io, AutoReverseDiff, "(")
+    !(backend.safe_mode) && print(io, "safe_mode=false")
+    print(io, ")")
 end
 
 """

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -296,7 +296,7 @@ end
 mode(::AutoTapir) = ReverseMode()
 
 function Base.show(io::IO, backend::AutoTapir)
-    print(io, AutoReverseDiff, "(")
+    print(io, AutoTapir, "(")
     !(backend.safe_mode) && print(io, "safe_mode=false")
     print(io, ")")
 end

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -111,11 +111,11 @@ mode(::AutoFiniteDiff) = ForwardMode()
 function Base.show(io::IO, backend::AutoFiniteDiff)
     print(io, AutoFiniteDiff, "(")
     backend.fdtype != Val(:forward) &&
-        print(io, "fdtype=", repr(backend.fdtype; context = io), ",")
+        print(io, "fdtype=", repr(backend.fdtype; context = io), ", ")
     backend.fdjtype != backend.fdtype &&
-        print(io, "fdjtype=", repr(backend.fdjtype; context = io), ",")
+        print(io, "fdjtype=", repr(backend.fdjtype; context = io), ", ")
     backend.fdhtype != Val(:hcentral) &&
-        print(io, "fdhtype=", repr(backend.fdhtype; context = io), ",")
+        print(io, "fdhtype=", repr(backend.fdhtype; context = io))
     print(io, ")")
 end
 
@@ -175,8 +175,9 @@ mode(::AutoForwardDiff) = ForwardMode()
 
 function Base.show(io::IO, backend::AutoForwardDiff{chunksize}) where {chunksize}
     print(io, AutoForwardDiff, "(")
-    chunksize !== nothing && print(io, "chunksize=", repr(chunksize; context = io), ",")
-    backend.tag !== nothing && print(io, "tag=", repr(backend.tag; context = io), ",")
+    chunksize !== nothing && print(io, "chunksize=", repr(chunksize; context = io),
+        (backend.tag !== nothing ? ", " : ""))
+    backend.tag !== nothing && print(io, "tag=", repr(backend.tag; context = io))
     print(io, ")")
 end
 
@@ -211,8 +212,9 @@ mode(::AutoPolyesterForwardDiff) = ForwardMode()
 
 function Base.show(io::IO, backend::AutoPolyesterForwardDiff{chunksize}) where {chunksize}
     print(io, AutoPolyesterForwardDiff, "(")
-    chunksize !== nothing && print(io, "chunksize=", repr(chunksize; context = io), ",")
-    backend.tag !== nothing && print(io, "tag=", repr(backend.tag; context = io), ",")
+    chunksize !== nothing && print(io, "chunksize=", repr(chunksize; context = io),
+        (backend.tag !== nothing ? ", " : ""))
+    backend.tag !== nothing && print(io, "tag=", repr(backend.tag; context = io))
     print(io, ")")
 end
 

--- a/src/legacy.jl
+++ b/src/legacy.jl
@@ -11,6 +11,8 @@
 
 @deprecate AutoSparseZygote() AutoSparse(AutoZygote())
 
+@deprecate AutoReverseDiff(compile) AutoReverseDiff(; compile)
+
 function mtk_to_symbolics(obj_sparse::Bool, cons_sparse::Bool)
     if obj_sparse || cons_sparse
         return AutoSparse(AutoSymbolics())

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -155,15 +155,15 @@ function AutoSparse(
 end
 
 function Base.show(io::IO, backend::AutoSparse)
-    s = "AutoSparse(dense_ad=$(repr(backend.dense_ad, context=io)), "
+    print(io, AutoSparse, "(dense_ad=", repr(backend.dense_ad, context = io), ",")
     if backend.sparsity_detector != NoSparsityDetector()
-        s *= "sparsity_detector=$(repr(backend.sparsity_detector, context=io)), "
+        print(io, "sparsity_detector=", repr(backend.sparsity_detector, context = io), ",")
     end
     if backend.coloring_algorithm != NoColoringAlgorithm()
-        s *= "coloring_algorithm=$(repr(backend.coloring_algorithm, context=io))), "
+        print(
+            io, "coloring_algorithm=", repr(backend.coloring_algorithm, context = io), ",")
     end
-    s = s[1:(end - 2)] * ")"
-    print(io, s)
+    print(io, ")")
 end
 
 """

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -155,13 +155,13 @@ function AutoSparse(
 end
 
 function Base.show(io::IO, backend::AutoSparse)
-    print(io, AutoSparse, "(dense_ad=", repr(backend.dense_ad, context = io), ",")
+    print(io, AutoSparse, "(dense_ad=", repr(backend.dense_ad, context = io))
     if backend.sparsity_detector != NoSparsityDetector()
-        print(io, "sparsity_detector=", repr(backend.sparsity_detector, context = io), ",")
+        print(io, ", sparsity_detector=", repr(backend.sparsity_detector, context = io))
     end
     if backend.coloring_algorithm != NoColoringAlgorithm()
         print(
-            io, "coloring_algorithm=", repr(backend.coloring_algorithm, context = io), ",")
+            io, ", coloring_algorithm=", repr(backend.coloring_algorithm, context = io))
     end
     print(io, ")")
 end

--- a/test/legacy.jl
+++ b/test/legacy.jl
@@ -58,3 +58,8 @@ end
     @test ad isa AbstractADType
     @test dense_ad(ad) isa AutoZygote
 end
+
+@testset "AutoReverseDiff without kwarg" begin
+    ad = @test_deprecated AutoReverseDiff(true)
+    @test ad.compile
+end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -7,6 +7,7 @@ end
 @testset "Printing" begin
     for ad in every_ad_with_options()
         @test startswith(string(ad), "Auto")
+        @test contains(string(ad), "(")
         @test endswith(string(ad), ")")
     end
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -20,3 +20,40 @@ end
     @test contains(string(sparse_backend1), string(AutoForwardDiff()))
     @test length(string(sparse_backend1)) < length(string(sparse_backend2))
 end
+
+import ADTypes
+
+struct FakeSparsityDetector <: ADTypes.AbstractSparsityDetector end
+struct FakeColoringAlgorithm <: ADTypes.AbstractColoringAlgorithm end
+
+for backend in [
+    # dense
+    ADTypes.AutoChainRules(; ruleconfig = :rc),
+    ADTypes.AutoDiffractor(),
+    ADTypes.AutoEnzyme(),
+    ADTypes.AutoEnzyme(mode = :forward),
+    ADTypes.AutoFastDifferentiation(),
+    ADTypes.AutoFiniteDiff(),
+    ADTypes.AutoFiniteDiff(fdtype = :fd, fdjtype = :fdj, fdhtype = :fdh),
+    ADTypes.AutoFiniteDifferences(; fdm = :fdm),
+    ADTypes.AutoForwardDiff(),
+    ADTypes.AutoForwardDiff(chunksize = 3, tag = :tag),
+    ADTypes.AutoPolyesterForwardDiff(),
+    ADTypes.AutoPolyesterForwardDiff(chunksize = 3, tag = :tag),
+    ADTypes.AutoReverseDiff(),
+    ADTypes.AutoReverseDiff(compile = true),
+    ADTypes.AutoSymbolics(),
+    ADTypes.AutoTapir(),
+    ADTypes.AutoTapir(safe_mode = false),
+    ADTypes.AutoTracker(),
+    ADTypes.AutoZygote(),
+    # sparse
+    ADTypes.AutoSparse(ADTypes.AutoForwardDiff()),
+    ADTypes.AutoSparse(
+        ADTypes.AutoForwardDiff();
+        sparsity_detector = FakeSparsityDetector(),
+        coloring_algorithm = FakeColoringAlgorithm()
+    )
+]
+    println(backend)
+end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Fix #65 and #66 

Should we test the round-trip-ability of these printings by parsing the string back into an object?
