### PR TITLE
Improve docstring for AutoTapir

### DIFF
--- a/src/dense.jl
+++ b/src/dense.jl
@@ -287,7 +287,13 @@ Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
 
 # Fields
 
-  - `safe_mode::Bool`: whether to run additional checks to catch errors early. On by default. Turn off to maximise performance if your code runs correctly.
+  - `safe_mode::Bool`: whether to run additional checks to catch errors early. While this is
+    on by default to ensure that users are aware of this option, you should generally turn
+    it off for actual use, as it has substantial performance implications.
+    If you encounter a problem with using Tapir (it fails to differentiate a function, or
+    something truly nasty like a segfault occurs), then you should try switching `safe_mode`
+    on and look at what happens. Often errors are caught earlier and the error messages are
+    more useful.
 """
 Base.@kwdef struct AutoTapir <: AbstractADType
     safe_mode::Bool = true


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

@yebai pointed out to me that `safe_mode` might be better called `debug_mode` -- he feels (and I agree) that "safe mode" sounds like something you want to have on, while "debug mode" sounds like something you only want to have on when a problem arises.

Unfortunately we've effectively committed to `safe_mode` already in this package -- in order to properly change over to `debug_mode` we'd have to rename the `safe_mode` field of the `AutoTapir` type. This would be a breaking change, so it's not something that we can do right now.

Instead, I've improved the docstring to provide a bit more context, and make it a bit clearer what the purpose of the mode is.
