### PR TITLE
Add deprecated non-kwarg AutoSparseReverseDiff constructor

### DIFF
--- a/src/legacy.jl
+++ b/src/legacy.jl
@@ -9,6 +9,8 @@
 
 @deprecate AutoSparseReverseDiff(; kwargs...) AutoSparse(AutoReverseDiff(; kwargs...))
 
+@deprecate AutoSparseReverseDiff(compile) AutoSparse(AutoReverseDiff(; compile))
+
 @deprecate AutoSparseZygote() AutoSparse(AutoZygote())
 
 @deprecate AutoReverseDiff(compile) AutoReverseDiff(; compile)

--- a/test/legacy.jl
+++ b/test/legacy.jl
@@ -51,6 +51,11 @@ end
     @test ad isa AbstractADType
     @test dense_ad(ad) isa AutoReverseDiff
     @test dense_ad(ad).compile
+
+    ad = @test_deprecated AutoSparseReverseDiff(true)
+    @test ad isa AbstractADType
+    @test dense_ad(ad) isa AutoReverseDiff
+    @test dense_ad(ad).compile
 end
 
 @testset "AutoSparseZygote" begin


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
