### PR TITLE
Deprecate "safe_mode" in favour of "debug_mode" for Tapir.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = [
     "Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors",
 ]
-version = "1.6.1"
+version = "1.6.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -331,11 +331,12 @@ Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
 
 # Constructors
 
-    AutoTapir(; safe_mode=true)
+    AutoTapir(; debug_mode::Bool)
 
 # Fields
 
-  - `safe_mode::Bool`: whether to run additional checks to catch errors early. While this is
+  - `safe_mode::Bool`: (to be renamed to `debug_mode` in the next breaking release)
+    whether to run additional checks to catch errors early. While this is
     on by default to ensure that users are aware of this option, you should generally turn
     it off for actual use, as it has substantial performance implications.
     If you encounter a problem with using Tapir (it fails to differentiate a function, or
@@ -343,15 +344,17 @@ Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
     on and look at what happens. Often errors are caught earlier and the error messages are
     more useful.
 """
-Base.@kwdef struct AutoTapir <: AbstractADType
-    safe_mode::Bool = true
+struct AutoTapir <: AbstractADType
+    safe_mode::Bool
 end
+
+AutoTapir(; debug_mode::Bool) = AutoTapir(debug_mode)
 
 mode(::AutoTapir) = ReverseMode()
 
 function Base.show(io::IO, backend::AutoTapir)
     print(io, AutoTapir, "(")
-    !(backend.safe_mode) && print(io, "safe_mode=false")
+    !(backend.safe_mode) && print(io, "debug_mode=false")
     print(io, ")")
 end
 

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -348,7 +348,34 @@ struct AutoTapir <: AbstractADType
     safe_mode::Bool
 end
 
-AutoTapir(; debug_mode::Bool) = AutoTapir(debug_mode)
+# This is a really awkward function to deprecate, because Julia does not dispatch on kwargs.
+function AutoTapir(;
+    debug_mode::Union{Bool, Nothing}=nothing, safe_mode::Union{Bool, Nothing}=nothing,
+)
+    if debug_mode !== nothing && safe_mode !== nothing
+        throw(ArgumentError(
+            "Both `debug_mode` and `safe_mode` have been set. Please only set `debug_mode`."
+        ))
+    end
+
+    if safe_mode !== nothing
+        Base.depwarn(
+            "AutoTapir(; safe_mode) is deprecated, use AutoTapir(; debug_mode) instead.",
+            ((Base.Core).Typeof(AutoTapir)).name.mt.name,
+        )
+        return AutoTapir(safe_mode)
+    end
+
+    if debug_mode === nothing
+        Base.depwarn(
+            "AutoTapir() is deprecated, use AutoTapir(; debug_mode=true) instead.",
+            ((Base.Core).Typeof(AutoTapir)).name.mt.name,
+        )
+        return AutoTapir(true)
+    else
+        return AutoTapir(debug_mode)
+    end
+end
 
 mode(::AutoTapir) = ReverseMode()
 

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -350,7 +350,7 @@ end
 
 # This is a really awkward function to deprecate, because Julia does not dispatch on kwargs.
 function AutoTapir(;
-    debug_mode::Union{Bool, Nothing}=nothing, safe_mode::Union{Bool, Nothing}=nothing,
+    debug_mode::Union{Bool, Nothing}=nothing, safe_mode::Union{Bool, Nothing}=nothing
 )
     if debug_mode !== nothing && safe_mode !== nothing
         throw(ArgumentError(

--- a/src/legacy.jl
+++ b/src/legacy.jl
@@ -15,6 +15,8 @@
 
 @deprecate AutoReverseDiff(compile) AutoReverseDiff(; compile)
 
+@deprecate AutoTapir() AutoTapir(; debug_mode=true),
+
 function mtk_to_symbolics(obj_sparse::Bool, cons_sparse::Bool)
     if obj_sparse || cons_sparse
         return AutoSparse(AutoSymbolics())

--- a/src/legacy.jl
+++ b/src/legacy.jl
@@ -15,8 +15,6 @@
 
 @deprecate AutoReverseDiff(compile) AutoReverseDiff(; compile)
 
-@deprecate AutoTapir() AutoTapir(; debug_mode=true)
-
 function mtk_to_symbolics(obj_sparse::Bool, cons_sparse::Bool)
     if obj_sparse || cons_sparse
         return AutoSparse(AutoSymbolics())

--- a/src/legacy.jl
+++ b/src/legacy.jl
@@ -15,7 +15,7 @@
 
 @deprecate AutoReverseDiff(compile) AutoReverseDiff(; compile)
 
-@deprecate AutoTapir() AutoTapir(; debug_mode=true),
+@deprecate AutoTapir() AutoTapir(; debug_mode=true)
 
 function mtk_to_symbolics(obj_sparse::Bool, cons_sparse::Bool)
     if obj_sparse || cons_sparse

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -155,9 +155,13 @@ end
     @test mode(ad) isa ReverseMode
     @test ad.safe_mode
 
-    @test_warn "" AutoTapir(; safe_mode = false)
-    ad = AutoTapir(; debug_mode = false)
+    ad = AutoTapir(; safe_mode = false)
     @test !ad.safe_mode
+
+    # Check that new interface works as intended.
+    @test_throws ArgumentError AutoTapir(; debug_mode=false, safe_mode=true)
+    @test !AutoTapir(; debug_mode=false).safe_mode
+    @test AutoTapir(; debug_mode=true).safe_mode
 end
 
 @testset "AutoTracker" begin

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -155,7 +155,8 @@ end
     @test mode(ad) isa ReverseMode
     @test ad.safe_mode
 
-    ad = AutoTapir(; safe_mode = false)
+    @test_warn "" AutoTapir(; safe_mode = false)
+    ad = AutoTapir(; debug_mode = false)
     @test !ad.safe_mode
 end
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Also deprecates a default choice in favour of requiring the user to specific whether they want `debug_mode` on / off.

The implementation is quite ugly, because we cannot use the usual `@deprecate` macro because Julia does not specialise on kwargs -- if you attempt to use the `@deprecate` macro, you'll find that you wind up overwriting existing methods, precompilation fails, and everything breaks. The only way I've been able to find to make this work is to create the new method with two kwargs added in this PR, in which each case is handled explicitly.

Unfortunately we cannot rename the `safe_mode` field of the `AutoTapir` type to `debug_mode` -- that will have to wait until 2.0. As a result I'm really not 100% convinced by this PR, but I'm going to let @gdalle and @yebai debate its merits. 