### PR TITLE
Modify Tapir.jl Implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = [
     "Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors",
 ]
-version = "1.6.1"
+version = "1.6.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -325,33 +325,31 @@ mode(::AutoSymbolics) = SymbolicMode()
 """
     AutoTapir
 
-Struct used to select the [Tapir.jl](https://github.com/withbayes/Tapir.jl) backend for automatic differentiation.
+Struct used to select the [Tapir.jl](https://github.com/compintell/Tapir.jl) backend for automatic differentiation.
 
 Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
 
 # Constructors
 
-    AutoTapir(; safe_mode=true)
+    AutoTapir(; debug_mode::Bool)
 
 # Fields
 
-  - `safe_mode::Bool`: whether to run additional checks to catch errors early. While this is
-    on by default to ensure that users are aware of this option, you should generally turn
-    it off for actual use, as it has substantial performance implications.
-    If you encounter a problem with using Tapir (it fails to differentiate a function, or
-    something truly nasty like a segfault occurs), then you should try switching `safe_mode`
-    on and look at what happens. Often errors are caught earlier and the error messages are
-    more useful.
+  - `debug_mode::Bool`: whether to run additional checks to catch errors early. This should
+    be set to `false` in general use of the package. If you encounter a problem when using
+    Tapir.jl (it fails to differentiate a function, or something truly nasty like a segfault
+    occurs), then you should switch `debug_mode` on. This often results in errors being
+    caught earlier in execution, and the associated error messages being more useful.
 """
 Base.@kwdef struct AutoTapir <: AbstractADType
-    safe_mode::Bool = true
+    debug_mode::Bool
 end
 
 mode(::AutoTapir) = ReverseMode()
 
 function Base.show(io::IO, backend::AutoTapir)
     print(io, AutoTapir, "(")
-    !(backend.safe_mode) && print(io, "safe_mode=false")
+    print(io, "debug_mode=$(backend.debug_mode)")
     print(io, ")")
 end
 

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -149,14 +149,14 @@ end
 end
 
 @testset "AutoTapir" begin
-    ad = AutoTapir()
+    ad = AutoTapir(debug_mode=true)
     @test ad isa AbstractADType
     @test ad isa AutoTapir
     @test mode(ad) isa ReverseMode
-    @test ad.safe_mode
+    @test ad.debug_mode
 
-    ad = AutoTapir(; safe_mode = false)
-    @test !ad.safe_mode
+    ad = AutoTapir(; debug_mode = false)
+    @test !ad.debug_mode
 end
 
 @testset "AutoTracker" begin

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -38,8 +38,8 @@ for backend in [
     ADTypes.AutoReverseDiff(),
     ADTypes.AutoReverseDiff(compile = true),
     ADTypes.AutoSymbolics(),
-    ADTypes.AutoTapir(),
-    ADTypes.AutoTapir(safe_mode = false),
+    ADTypes.AutoTapir(debug_mode = true),
+    ADTypes.AutoTapir(debug_mode = false),
     ADTypes.AutoTracker(),
     ADTypes.AutoZygote(),
     # sparse

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,7 +46,8 @@ function every_ad()
         AutoPolyesterForwardDiff(),
         AutoReverseDiff(),
         AutoSymbolics(),
-        AutoTapir(),
+        AutoTapir(debug_mode = true),
+        AutoTapir(debug_mode = false),
         AutoTracker(),
         AutoZygote()
     ]
@@ -69,8 +70,8 @@ function every_ad_with_options()
         AutoReverseDiff(),
         AutoReverseDiff(compile = true),
         AutoSymbolics(),
-        AutoTapir(),
-        AutoTapir(safe_mode = false),
+        AutoTapir(debug_mode = true),
+        AutoTapir(debug_mode = false),
         AutoTracker(),
         AutoZygote()
     ]

--- a/test/symbols.jl
+++ b/test/symbols.jl
@@ -11,7 +11,7 @@ using Test
 @test ADTypes.Auto(:PolyesterForwardDiff) isa AutoPolyesterForwardDiff
 @test ADTypes.Auto(:ReverseDiff) isa AutoReverseDiff
 @test ADTypes.Auto(:Symbolics) isa AutoSymbolics
-@test ADTypes.Auto(:Tapir) isa AutoTapir
+@test ADTypes.Auto(:Tapir; debug_mode=false) isa AutoTapir
 @test ADTypes.Auto(:Tracker) isa AutoTracker
 @test ADTypes.Auto(:Zygote) isa AutoZygote
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This does two things:
1. rename `safe_mode` field of AutoTapir to `debug_mode`,
2. remove default value, in order to force users to make a choice.

Follow up from #75 . Per discussion with @ChrisRackauckas , this is breaking.

@yebai @gdalle  are you both okay with this?
