### PR TITLE
Add `function_annotation` to `AutoEnzyme`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = [
     "Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors",
 ]
-version = "1.6.2"
+version = "1.7.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -39,7 +39,7 @@ struct AutoDiffractor <: AbstractADType end
 mode(::AutoDiffractor) = ForwardOrReverseMode()
 
 """
-    AutoEnzyme{M}
+    AutoEnzyme{M,A}
 
 Struct used to select the [Enzyme.jl](https://github.com/EnzymeAD/Enzyme.jl) backend for automatic differentiation.
 
@@ -47,28 +47,37 @@ Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
 
 # Constructors
 
-    AutoEnzyme(; mode=nothing)
+    AutoEnzyme(; mode::M=nothing, function_annotation::Type{A}=Nothing)
+
+# Type parameters
+
+  - `A` determines how the function `f` to differentiate is passed to Enzyme. It can be:
+
+      + a subtype of `EnzymeCore.Annotation` (like `EnzymeCore.Const` or `EnzymeCore.Duplicated`) to enforce a given annotation
+      + `Nothing` to simply pass `f` and let Enzyme choose the most appropriate annotation
 
 # Fields
 
-  - `mode::M`: can be either
+  - `mode::M` determines the autodiff mode (forward or reverse). It can be:
 
       + an object subtyping `EnzymeCore.Mode` (like `EnzymeCore.Forward` or `EnzymeCore.Reverse`) if a specific mode is required
       + `nothing` to choose the best mode automatically
 """
-struct AutoEnzyme{M} <: AbstractADType
+struct AutoEnzyme{M, A} <: AbstractADType
     mode::M
 end
 
-function AutoEnzyme(; mode::M = nothing) where {M}
-    return AutoEnzyme{M}(mode)
+function AutoEnzyme(;
+        mode::M = nothing, function_annotation::Type{A} = Nothing) where {M, A}
+    return AutoEnzyme{M, A}(mode)
 end
 
 mode(::AutoEnzyme) = ForwardOrReverseMode()  # specialized in the extension
 
-function Base.show(io::IO, backend::AutoEnzyme)
+function Base.show(io::IO, backend::AutoEnzyme{M, A}) where {M, A}
     print(io, AutoEnzyme, "(")
-    !isnothing(backend.mode) && print(io, "mode=", repr(backend.mode; context = io))
+    !isnothing(backend.mode) && print(io, "mode=", repr(backend.mode; context = io), ", ")
+    print(io, "function_annotation=", repr(A; context = io))
     print(io, ")")
 end
 

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -76,8 +76,9 @@ mode(::AutoEnzyme) = ForwardOrReverseMode()  # specialized in the extension
 
 function Base.show(io::IO, backend::AutoEnzyme{M, A}) where {M, A}
     print(io, AutoEnzyme, "(")
-    !isnothing(backend.mode) && print(io, "mode=", repr(backend.mode; context = io), ", ")
-    print(io, "function_annotation=", repr(A; context = io))
+    !isnothing(backend.mode) && print(io, "mode=", repr(backend.mode; context = io))
+    !isnothing(backend.mode) && !(A <: Nothing) && print(io, ", ")
+    !(A <: Nothing) && print(io, "function_annotation=", repr(A; context = io))
     print(io, ")")
 end
 

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -28,25 +28,26 @@ end
 @testset "AutoEnzyme" begin
     ad = AutoEnzyme()
     @test ad isa AbstractADType
-    @test ad isa AutoEnzyme{Nothing}
+    @test ad isa AutoEnzyme{Nothing, Nothing}
     @test mode(ad) isa ForwardOrReverseMode
     @test ad.mode === nothing
 
-    ad = AutoEnzyme(EnzymeCore.Forward)
-    @test ad isa AbstractADType
-    @test ad isa AutoEnzyme{typeof(EnzymeCore.Forward)}
-    @test mode(ad) isa ForwardMode
-    @test ad.mode == EnzymeCore.Forward
-
     ad = AutoEnzyme(; mode = EnzymeCore.Forward)
     @test ad isa AbstractADType
-    @test ad isa AutoEnzyme{typeof(EnzymeCore.Forward)}
+    @test ad isa AutoEnzyme{typeof(EnzymeCore.Forward), Nothing}
     @test mode(ad) isa ForwardMode
     @test ad.mode == EnzymeCore.Forward
 
-    ad = AutoEnzyme(; mode = EnzymeCore.Reverse)
+    ad = AutoEnzyme(; function_annotation = EnzymeCore.Const)
     @test ad isa AbstractADType
-    @test ad isa AutoEnzyme{typeof(EnzymeCore.Reverse)}
+    @test ad isa AutoEnzyme{Nothing, EnzymeCore.Const}
+    @test mode(ad) isa ForwardOrReverseMode
+    @test ad.mode === nothing
+
+    ad = AutoEnzyme(;
+        mode = EnzymeCore.Reverse, function_annotation = EnzymeCore.Duplicated)
+    @test ad isa AbstractADType
+    @test ad isa AutoEnzyme{typeof(EnzymeCore.Reverse), EnzymeCore.Duplicated}
     @test mode(ad) isa ReverseMode
     @test ad.mode == EnzymeCore.Reverse
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -21,6 +21,11 @@ end
     @test length(string(sparse_backend1)) < length(string(sparse_backend2))
 end
 
+#=
+The following tests are only for visual assessment of the printing behavior.
+They do not correspond to proper use of ADTypes constructors.
+Please refer to the docstrings for that.
+=#
 for backend in [
     # dense
     ADTypes.AutoChainRules(; ruleconfig = :rc),

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -27,6 +27,8 @@ for backend in [
     ADTypes.AutoDiffractor(),
     ADTypes.AutoEnzyme(),
     ADTypes.AutoEnzyme(mode = :forward),
+    ADTypes.AutoEnzyme(function_annotation = Val{:forward}),
+    ADTypes.AutoEnzyme(mode = :reverse, function_annotation = Val{:duplicated}),
     ADTypes.AutoFastDifferentiation(),
     ADTypes.AutoFiniteDiff(),
     ADTypes.AutoFiniteDiff(fdtype = :fd, fdjtype = :fdj, fdhtype = :fdh),


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This PR adds a type parameter `A` to `AutoEnzyme` and a keyword argument `function_annotation::Type{A}` to its constructor.
It is the second attempt at properly solving the following issues:

- https://github.com/EnzymeAD/Enzyme.jl/issues/1669
- https://github.com/gdalle/DifferentiationInterface.jl/issues/339