### PR TITLE
Remove mention of SparseDiffTools in AbstractColoringAlgorithm

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = [
     "Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors",
 ]
-version = "1.7.0"
+version = "1.7.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -47,7 +47,7 @@ hessian_sparsity(f, x, ::NoSparsityDetector) = trues(length(x), length(x))
 """
     AbstractColoringAlgorithm
 
-Abstract supertype for Jacobian/Hessian coloring algorithms, defined for example in [SparseDiffTools.jl](https://github.com/JuliaDiff/SparseDiffTools.jl).
+Abstract supertype for Jacobian/Hessian coloring algorithms.
 
 # Required methods
 
@@ -59,11 +59,7 @@ Abstract supertype for Jacobian/Hessian coloring algorithms, defined for example
 
 The terminology and definitions are taken from the following paper:
 
-> "What Color Is Your Jacobian? Graph Coloring for Computing Derivatives"
-> 
-> Assefaw Hadish Gebremedhin, Fredrik Manne, and Alex Pothen (2005)
-> 
-> https://epubs.siam.org/doi/10.1137/S0036144504444711
+> [_What Color Is Your Jacobian? Graph Coloring for Computing Derivatives_](https://epubs.siam.org/doi/10.1137/S0036144504444711), Assefaw Hadish Gebremedhin, Fredrik Manne, and Alex Pothen (2005)
 """
 abstract type AbstractColoringAlgorithm end
 


### PR DESCRIPTION
- Remove pointer to SparseDiffTools from the docstring of the `AbstractColoringAlgorithm` type, because SparseDiffTools does not implement it (even though it has some of the underlying algortihms)
- Bump version to v1.7.1