### PR TITLE
Add the relstep and absstep parameters to AutoFiniteDiff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ADTypes"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors"]
-version = "1.11.0"
+version = "1.12.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -113,8 +113,8 @@ Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
   - `fdtype::T1`: finite difference type
   - `fdjtype::T2`: finite difference type for the Jacobian
   - `fdhtype::T3`: finite difference type for the Hessian
-  - `relstep: relative finite difference step size`
-  - `absstep: absolute finite difference step size`
+  - `relstep`: relative finite difference step size
+  - `absstep`: absolute finite difference step size
 """
 Base.@kwdef struct AutoFiniteDiff{T1, T2, T3} <: AbstractADType
     fdtype::T1 = Val(:forward)

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -106,13 +106,15 @@ Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
 
 # Constructors
 
-    AutoFiniteDiff(; fdtype=Val(:forward), fdjtype=fdtype, fdhtype=Val(:hcentral))
+    AutoFiniteDiff(; fdtype=Val(:forward), fdjtype=fdtype, fdhtype=Val(:hcentral), relstep=nothing, absstep=nothing)
 
 # Fields
 
   - `fdtype::T1`: finite difference type
   - `fdjtype::T2`: finite difference type for the Jacobian
   - `fdhtype::T3`: finite difference type for the Hessian
+  - `relstep: relative finite difference step size`
+  - `absstep: absolute finite difference step size`
 """
 Base.@kwdef struct AutoFiniteDiff{T1, T2, T3} <: AbstractADType
     fdtype::T1 = Val(:forward)

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -118,6 +118,8 @@ Base.@kwdef struct AutoFiniteDiff{T1, T2, T3} <: AbstractADType
     fdtype::T1 = Val(:forward)
     fdjtype::T2 = fdtype
     fdhtype::T3 = Val(:hcentral)
+    relstep = nothing
+    absstep = nothing
 end
 
 mode(::AutoFiniteDiff) = ForwardMode()
@@ -129,7 +131,11 @@ function Base.show(io::IO, backend::AutoFiniteDiff)
     backend.fdjtype != backend.fdtype &&
         print(io, "fdjtype=", repr(backend.fdjtype; context = io), ", ")
     backend.fdhtype != Val(:hcentral) &&
-        print(io, "fdhtype=", repr(backend.fdhtype; context = io))
+        print(io, "fdhtype=", repr(backend.fdhtype; context = io), ", ")
+    !isnothing(backend.relstep) &&
+        print(io, "relstep=", repr(backend.relstep; context = io), ", ")
+    !isnothing(backend.absstep) &&
+        print(io, "absstep=", repr(backend.absstep; context = io))
     print(io, ")")
 end
 

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -67,14 +67,18 @@ end
     @test ad.fdtype === Val(:forward)
     @test ad.fdjtype === Val(:forward)
     @test ad.fdhtype === Val(:hcentral)
+    @test ad.relstep === nothing
+    @test ad.absstep === nothing
 
-    ad = AutoFiniteDiff(; fdtype = Val(:central), fdjtype = Val(:forward))
+    ad = AutoFiniteDiff(; fdtype = Val(:central), fdjtype = Val(:forward), relstep = 1e-3, absstep = 1e-3)
     @test ad isa AbstractADType
     @test ad isa AutoFiniteDiff
     @test mode(ad) isa ForwardMode
     @test ad.fdtype === Val(:central)
     @test ad.fdjtype === Val(:forward)
     @test ad.fdhtype === Val(:hcentral)
+    @test ad.relstep == 1e-3
+    @test ad.absstep == 1e-3
 end
 
 @testset "AutoFiniteDifferences" begin

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -78,7 +78,7 @@ end
     @test ad.fdjtype === Val(:forward)
     @test ad.fdhtype === Val(:hcentral)
     @test ad.relstep == 1e-3
-    @test ad.absstep == 1e-3
+    @test ad.absstep == 1e-4
 end
 
 @testset "AutoFiniteDifferences" begin

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -70,7 +70,7 @@ end
     @test ad.relstep === nothing
     @test ad.absstep === nothing
 
-    ad = AutoFiniteDiff(; fdtype = Val(:central), fdjtype = Val(:forward), relstep = 1e-3, absstep = 1e-3)
+    ad = AutoFiniteDiff(; fdtype = Val(:central), fdjtype = Val(:forward), relstep = 1e-3, absstep = 1e-4)
     @test ad isa AbstractADType
     @test ad isa AutoFiniteDiff
     @test mode(ad) isa ForwardMode


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Fixes #101 
Adds the relstep and absstep parameters from the FiniteDiff [API](https://docs.sciml.ai/FiniteDiff/stable/api/)