### PR TITLE
fix: add type annotation to step parameters in AutoFiniteDiff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ADTypes"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors"]
-version = "1.12.0"
+version = "1.12.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -116,12 +116,12 @@ Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
   - `relstep`: relative finite difference step size
   - `absstep`: absolute finite difference step size
 """
-Base.@kwdef struct AutoFiniteDiff{T1, T2, T3} <: AbstractADType
+Base.@kwdef struct AutoFiniteDiff{T1, T2, T3, S1, S2} <: AbstractADType
     fdtype::T1 = Val(:forward)
     fdjtype::T2 = fdtype
     fdhtype::T3 = Val(:hcentral)
-    relstep = nothing
-    absstep = nothing
+    relstep::S1 = nothing
+    absstep::S2 = nothing
 end
 
 mode(::AutoFiniteDiff) = ForwardMode()


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

#102 added the `relstep` and `absstep` parameters without type annotations, which is equivalent to `::Any`. This PR fixes it.
