### PR TITLE
feat: make `dense_ad` act as the identity on a dense backend

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ADTypes"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors"]
-version = "1.13.0"
+version = "1.14.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -225,14 +225,16 @@ end
 
 """
     dense_ad(ad::AutoSparse)::AbstractADType
+    dense_ad(ad::AbstractADType)::AbstractADType
 
-Return the underlying AD package for a sparse AD choice.
+Return the underlying AD package for a sparse AD choice, acts as the identity on a dense AD choice.
 
 # See also
 
   - [`AutoSparse`](@ref)
 """
 dense_ad(ad::AutoSparse) = ad.dense_ad
+dense_ad(ad::AbstractADType) = ad
 
 mode(sparse_ad::AutoSparse) = mode(dense_ad(sparse_ad))
 

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -227,7 +227,7 @@ end
     dense_ad(ad::AutoSparse)::AbstractADType
     dense_ad(ad::AbstractADType)::AbstractADType
 
-Return the underlying AD package for a sparse AD choice, acts as the identity on a dense AD choice.
+Return the underlying AD package for a sparse AD choice, act as the identity on a dense AD choice.
 
 # See also
 

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -11,6 +11,7 @@
         elseif mode(ad) isa SymbolicMode
             @test mode(sparse_ad) isa SymbolicMode
         end
+        @test dense_ad(ad) == ad
         @test dense_ad(sparse_ad) == ad
         @test sparsity_detector(sparse_ad) == NoSparsityDetector()
         @test coloring_algorithm(sparse_ad) == NoColoringAlgorithm()


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Adds a natural default `dense_ad(ad::AbstractADType) = ad` to help avoid the following pattern:

```julia
if ad isa AutoSparse
    dense_ad(ad)
else
    ad
end
```