### PR TITLE
Add DI warning to AutoEnzyme

### DIFF
--- a/src/dense.jl
+++ b/src/dense.jl
@@ -45,6 +45,11 @@ Struct used to select the [Enzyme.jl](https://github.com/EnzymeAD/Enzyme.jl) bac
 
 Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
 
+!!! warning
+    `AutoEnzyme` can be used by [DifferentiationInterface.jl](https://github.com/JuliaDiff/DifferentiationInterface.jl) to access a restricted subset of Enzyme.jl functionality.
+    If your code or one of its dependencies computes derivatives through DifferentiationInterface.jl, you might experience slowdowns or errors that would not happen with Enzyme.jl's native API.
+    In that case, please refer to the [Enzyme.jl documentation](https://enzymead.github.io/Enzyme.jl/stable/) for details on how to call its native API.
+
 # Constructors
 
     AutoEnzyme(; mode::M=nothing, function_annotation::Type{A}=Nothing)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Calling Enzyme through DI can introduce errors or slowdowns compared to Enzyme's native API. However, end users are unlikely to check out either the DI docs or the Enzyme docs when investigating what happened, especially when derivatives are deep in the call stack.
On the other hand, end users usually provide the `AutoEnzyme` object to whatever package they are using. Thus, adding a warning there seems like a good way to raise awareness.

@wsmoses what do you think? You could also write a page for the Enzyme docs with examples of what can go wrong when going through DI, and we could link it from here and from the DI docs.
