### PR TITLE
Allow calling `AutoMooncake()` without the `config` keyword

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ADTypes"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors"]
-version = "1.14.1"
+version = "1.15.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ADTypes"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors"]
-version = "1.15.1"
+version = "1.15.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -282,14 +282,14 @@ Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
 
 # Constructors
 
-    AutoMooncake(; config)
+    AutoMooncake(; config=nothing)
 
 # Fields
 
   - `config`: either `nothing` or an instance of `Mooncake.Config` -- see the docstring of `Mooncake.Config` for more information. `AutoMooncake(; config=nothing)` is equivalent to `AutoMooncake(; config=Mooncake.Config())`, i.e. the default configuration.
 """
 Base.@kwdef struct AutoMooncake{Tconfig} <: AbstractADType
-    config::Tconfig
+    config::Tconfig = nothing
 end
 
 mode(::AutoMooncake) = ReverseMode()

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -71,7 +71,8 @@ end
     @test ad.absstep === nothing
     @test ad.dir
 
-    ad = AutoFiniteDiff(; fdtype = Val(:central), fdjtype = Val(:forward), relstep = 1e-3, absstep = 1e-4, dir = false)
+    ad = AutoFiniteDiff(; fdtype = Val(:central), fdjtype = Val(:forward),
+        relstep = 1e-3, absstep = 1e-4, dir = false)
     @test ad isa AbstractADType
     @test ad isa AutoFiniteDiff
     @test mode(ad) isa ForwardMode
@@ -126,10 +127,12 @@ end
 end
 
 @testset "AutoMooncake" begin
-    ad = AutoMooncake(; config=nothing)
+    ad = AutoMooncake(; config = :config)
     @test ad isa AbstractADType
     @test ad isa AutoMooncake
     @test mode(ad) isa ReverseMode
+    @test ad.config == :config
+    ad = AutoMooncake()
     @test ad.config === nothing
 end
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Fixes #111 
