### PR TITLE
Fix docstring typos and add missing backends to Auto function

### DIFF
--- a/src/dense.jl
+++ b/src/dense.jl
@@ -365,7 +365,7 @@ Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
 
 # Fields
 
-  - `config`: either `nothing` or an instance of `Mooncake.Config` -- see the docstring of `Mooncake.Config` for more information. `AutoForwardMooncake(; config=nothing)` is equivalent to `AutoForwardMooncake(; config=Mooncake.Config())`, i.e. the default configuration.
+  - `config`: either `nothing` or an instance of `Mooncake.Config` -- see the docstring of `Mooncake.Config` for more information. `AutoMooncakeForward(; config=nothing)` is equivalent to `AutoMooncakeForward(; config=Mooncake.Config())`, i.e. the default configuration.
 """
 Base.@kwdef struct AutoMooncakeForward{Tconfig} <: AbstractADType
     config::Tconfig = nothing
@@ -573,7 +573,7 @@ struct NoAutoDiff <: AbstractADType end
 
 Signifies that code tried to use automatic differentiation, but [`NoAutoDiff`](@ref) was specified.
 
-# Constructor
+# Constructors
 
     NoAutoDiffSelectedError(msg::String)
 """

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -23,8 +23,8 @@ ADTypes.AutoZygote()
 Auto(package::Symbol, args...; kws...) = Auto(Val(package), args...; kws...)
 
 for backend in (:ChainRules, :Diffractor, :Enzyme, :Reactant, :FastDifferentiation,
-    :FiniteDiff, :FiniteDifferences, :ForwardDiff, :Mooncake, :PolyesterForwardDiff,
-    :ReverseDiff, :Symbolics, :Tapir, :Tracker, :Zygote)
+    :FiniteDiff, :FiniteDifferences, :ForwardDiff, :GTPSA, :Mooncake, :PolyesterForwardDiff,
+    :ReverseDiff, :Symbolics, :Tapir, :TaylorDiff, :Tracker, :Zygote)
     @eval Auto(::Val{$(QuoteNode(backend))}, args...; kws...) = $(Symbol(:Auto, backend))(
         args...; kws...)
 end


### PR DESCRIPTION
## Summary

- Fix typo in `AutoMooncakeForward` docstring: `AutoForwardMooncake` -> `AutoMooncakeForward`
- Fix inconsistent header in `NoAutoDiffSelectedError` docstring: "Constructor" -> "Constructors" (matches all other docstrings)
- Add missing `GTPSA` and `TaylorDiff` to `ADTypes.Auto` symbol lookup (these backends are exported but were not included in the `Auto` convenience function)

## Test plan

- [x] Documentation builds without warnings
- [x] All package tests pass (`Pkg.test()`)

/cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)