### PR TITLE
Centralize CI to SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,6 @@ concurrency:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -25,22 +24,9 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg, TOML
-      - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: ${{ matrix.version }}
+      julia-arch: ${{ matrix.arch }}
+      os: ${{ matrix.os }}
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -13,25 +13,16 @@ on:
 jobs:
   test:
     if: false
-    runs-on: ubuntu-latest
+    name: "Downgrade"
     strategy:
       matrix:
         group:
           - Core
-        downgrade_mode: ['alldeps']
         julia-version: ['1.10', '1', 'pre']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: ${{ matrix.julia-version }}
+      group: ${{ matrix.group }}
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.16.23 
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the ADTypes.jl CI to the centralized SciML reusable workflows (pinned `@v1`, `secrets: "inherit"` on every caller). End-state matches the Sundials.jl model: Tests, Documentation, Runic, SpellCheck, and Downgrade are all dispatched through `SciML/.github`.

## Converted (inline -> central caller)
- **CI.yml**: inline test job -> `tests.yml@v1`. Preserves the exact matrix `version: [lts, 1, pre] x os: [ubuntu-latest] x arch: [x64]`. (The old inline `julia-downgrade-compat` step was gated on `matrix.version == '1.6'`, which never matched the matrix, so it was dead code and is dropped. Codecov upload is handled by the central workflow.)
- **FormatCheck.yml**: inline `fredrikekre/runic-action` -> `runic.yml@v1`.
- **SpellCheck.yml**: inline `crate-ci/typos` -> `spellcheck.yml@v1`.
- **Downgrade.yml**: inline -> `downgrade.yml@v1`. Preserves `if: false`, the `Core` group, julia-versions `['1.10','1','pre']`, `skip: Pkg,TOML`, and `allow-reresolve: false`.

## Unchanged
- **Documentation.yml**: already a `documentation.yml@v1` caller with `secrets: "inherit"`.
- **TagBot.yml**: left as-is per instructions.

## Other changes
- **dependabot.yml**: removed the obsolete `crate-ci/typos` ignore (the typos version is now pinned inside the central `spellcheck.yml`); trimmed the `julia` ecosystem `directories` to those that actually have a `Project.toml` (`/` and `/docs`; `/test` has none — test deps live in `[extras]`/`[targets]`).

## Checks
- Typos: ran `typos .` — already clean (exit 0), **0 typos fixed**.
- Runic: ran `Runic.main(["--inplace","."])` — **no formatting changes** (repo was already Runic-clean from the prior inline check).
- All changed YAML validated with `yaml.safe_load`.

## Heads up
The check job names change (e.g. the test jobs now render via the reusable workflow). **Branch-protection required-status-check names will need updating** to match the new caller/job names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
