### PR TITLE
Split tests into Core/QA groups; CI.yml -> grouped-tests.yml caller

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,22 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
-  test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - 'lts'
-          - '1'
-          - 'pre'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: ${{ matrix.version }}
-      julia-arch: ${{ matrix.arch }}
-      os: ${{ matrix.os }}
+  tests:
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/Project.toml
+++ b/Project.toml
@@ -20,12 +20,11 @@ EnzymeCore = "0.5.3,0.6,0.7,0.8"
 julia = "1.10"
 
 [extras]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ChainRulesCore", "EnzymeCore", "JET", "Setfield", "Test"]
+test = ["ChainRulesCore", "EnzymeCore", "Pkg", "Setfield", "Test"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,0 +1,17 @@
+[deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+ADTypes = {path = "../.."}
+
+[compat]
+ADTypes = "1"
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+Pkg = "1"
+Test = "1"
+julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,0 +1,12 @@
+using ADTypes
+using Aqua: Aqua
+using JET: JET
+using Test
+
+@testset "Aqua.jl" begin
+    Aqua.test_all(ADTypes; deps_compat = (check_extras = false,))
+end
+
+@testset "JET.jl" begin
+    JET.test_package(ADTypes, target_defined_modules = true)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using Pkg
 using ADTypes
 using ADTypes: AbstractADType,
     mode,
@@ -17,13 +18,23 @@ using ADTypes: dense_ad,
     column_coloring,
     row_coloring,
     symmetric_coloring
-using Aqua: Aqua
 using ChainRulesCore: ChainRulesCore, RuleConfig,
     HasForwardsMode, HasReverseMode,
     NoForwardsMode, NoReverseMode
 using EnzymeCore: EnzymeCore
-using JET: JET
 using Test
+
+const GROUP = get(ENV, "GROUP", "All")
+
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    # On Julia < 1.11 the [sources] section in the qa Project.toml is not honored,
+    # so Pkg.develop the package root path explicitly to test the PR branch code.
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
 
 ## Backend-specific
 
@@ -91,33 +102,34 @@ end
 
 ## Tests
 
-@testset verbose = true "ADTypes.jl" begin
-    if VERSION >= v"1.10"
-        @testset "Aqua.jl" begin
-            Aqua.test_all(ADTypes; deps_compat = (check_extras = false,))
+if GROUP == "All" || GROUP == "Core"
+    @testset verbose = true "ADTypes.jl" begin
+        @testset "Dense" begin
+            include("dense.jl")
         end
-        @testset "JET.jl" begin
-            JET.test_package(ADTypes, target_defined_modules = true)
+        @testset "Sparse" begin
+            include("sparse.jl")
+        end
+        @testset "Symbols" begin
+            include("symbols.jl")
+        end
+        @testset "Legacy" begin
+            include("legacy.jl")
+        end
+        @testset "Miscellaneous" begin
+            include("misc.jl")
+        end
+        if VERSION >= v"1.11.0-DEV.469"
+            @testset "Public" begin
+                include("public.jl")
+            end
         end
     end
-    @testset "Dense" begin
-        include("dense.jl")
-    end
-    @testset "Sparse" begin
-        include("sparse.jl")
-    end
-    @testset "Symbols" begin
-        include("symbols.jl")
-    end
-    @testset "Legacy" begin
-        include("legacy.jl")
-    end
-    @testset "Miscellaneous" begin
-        include("misc.jl")
-    end
-    if VERSION >= v"1.11.0-DEV.469"
-        @testset "Public" begin
-            include("public.jl")
-        end
+end
+
+if GROUP == "QA"
+    activate_qa_env()
+    @testset "Quality Assurance" begin
+        include(joinpath(@__DIR__, "qa", "qa.jl"))
     end
 end

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,5 @@
+[Core]
+versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
## Summary

Refactors ADTypes' test suite to the canonical SciML **Core/QA** group layout and turns `CI.yml` into a thin caller of the centralized reusable **grouped-tests** workflow. The version/group matrix now lives in `test/test_groups.toml` instead of being hand-maintained in `CI.yml`.

### Changes
- **`test/runtests.jl`** — add `GROUP` dispatch (default `"All"`). The functional tests (`Dense`/`Sparse`/`Symbols`/`Legacy`/`Miscellaneous`/`Public`) run under `GROUP == "Core" || "All"`. `Aqua.test_all` + `JET.test_package` move into a `"QA"` group that activates the light `test/qa` env via `Pkg.activate(joinpath(@__DIR__, "qa"))` (plus an explicit `Pkg.develop` on Julia < 1.11 where `[sources]` is not honored) before running. The original Aqua/JET options are preserved (`deps_compat = (check_extras = false,)`, `target_defined_modules = true`).
- **`test/qa/Project.toml`** + **`test/qa/qa.jl`** — new light QA environment carrying only `Aqua`, `JET`, `Pkg`, `Test` and the package itself via `[sources] path = "../.."`.
- **`Project.toml`** — drop `Aqua`/`JET` from the main test `[extras]`/`[targets]` (they live only in the QA env now) and add `Pkg` (needed by `runtests.jl` to activate the QA env).
- **`test/test_groups.toml`** — `Core` on `[lts, 1, pre]`, `QA` on `[lts, 1]`.
- **`.github/workflows/CI.yml`** — replace the version matrix that called `tests.yml@v1` with a thin caller of `grouped-tests.yml@v1`. Existing triggers (`push` to `main` + `tags`, `pull_request`) and concurrency settings are preserved. No other workflows touched.

### Local verification (Julia 1.11.9)
- **Core group** (`GROUP=Core`): `ADTypes.jl | 507 507` — **PASS**
- **QA group** (`GROUP=QA`): `Quality Assurance | 11 11` — **PASS** (Aqua 0.8.16 + JET 0.9.20 resolved through the light `test/qa` env via `[sources]`)

JET resolves to 0.9.20 on Julia 1.11 (newer JET majors require Julia ≥ 1.12); the QA `[compat]` allows `0.9, 0.10, 0.11` so newer Julia versions pick up newer JET.

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)