### PR TITLE
Use SciMLTesting v1.2 (folder-based run_tests)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,14 +17,17 @@ ADTypesEnzymeCoreExt = "EnzymeCore"
 ChainRulesCore = "1.0.2"
 ConstructionBase = "1.5"
 EnzymeCore = "0.5.3,0.6,0.7,0.8"
+SafeTestsets = "0.1, 1"
+SciMLTesting = "1"
 julia = "1.10"
 
 [extras]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ChainRulesCore", "EnzymeCore", "Pkg", "Setfield", "Test"]
+test = ["ChainRulesCore", "EnzymeCore", "SafeTestsets", "SciMLTesting", "Setfield", "Test"]

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "shared", "test_setup.jl"))
+
 @testset "AutoChainRules" begin
     ad = AutoChainRules(; ruleconfig = ForwardOrReverseRuleConfig())
     @test ad isa AbstractADType

--- a/test/legacy.jl
+++ b/test/legacy.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "shared", "test_setup.jl"))
+
 @testset "AutoModelingToolkit" begin
     ad_sparse1 = @test_deprecated AutoModelingToolkit(;
         obj_sparse = true, cons_sparse = false

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "shared", "test_setup.jl"))
+
 @testset "Broadcasting" begin
     for ad in every_ad()
         @test identity.(ad) == ad

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,7 +2,8 @@
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -12,6 +13,7 @@ ADTypes = {path = "../.."}
 ADTypes = "1"
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
-Pkg = "1"
+SafeTestsets = "0.1, 1"
+SciMLTesting = "1"
 Test = "1"
 julia = "1.10"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,135 +1,24 @@
-using Pkg
+using SafeTestsets
+using SciMLTesting
+# `using ADTypes` in Main is load-bearing for the printing tests: Julia qualifies a
+# type's module in `show` based on visibility in `Base.active_module()` (Main), not the
+# module the test runs in. Without it, `string(AutoForwardDiff())` becomes
+# "ADTypes.AutoForwardDiff()" and the `startswith(..., "Auto")` assertions fail.
 using ADTypes
-using ADTypes: AbstractADType,
-    mode,
-    ForwardMode,
-    ForwardOrReverseMode,
-    ReverseMode,
-    SymbolicMode
-using ADTypes: dense_ad,
-    NoSparsityDetector,
-    KnownJacobianSparsityDetector,
-    KnownHessianSparsityDetector,
-    sparsity_detector,
-    jacobian_sparsity,
-    hessian_sparsity,
-    NoColoringAlgorithm,
-    coloring_algorithm,
-    column_coloring,
-    row_coloring,
-    symmetric_coloring
-using ChainRulesCore: ChainRulesCore, RuleConfig,
-    HasForwardsMode, HasReverseMode,
-    NoForwardsMode, NoReverseMode
-using EnzymeCore: EnzymeCore
-using Test
 
-const GROUP = get(ENV, "GROUP", "All")
-
-function activate_qa_env()
-    Pkg.activate(joinpath(@__DIR__, "qa"))
-    # On Julia < 1.11 the [sources] section in the qa Project.toml is not honored,
-    # so Pkg.develop the package root path explicitly to test the PR branch code.
-    if VERSION < v"1.11.0-DEV.0"
-        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
-    end
-    return Pkg.instantiate()
-end
-
-## Backend-specific
-
-struct CustomTag end
-
-struct ForwardRuleConfig <: RuleConfig{Union{HasForwardsMode, NoReverseMode}} end
-struct ReverseRuleConfig <: RuleConfig{Union{NoForwardsMode, HasReverseMode}} end
-struct ForwardOrReverseRuleConfig <: RuleConfig{Union{HasForwardsMode, HasReverseMode}} end
-
-struct FakeSparsityDetector <: ADTypes.AbstractSparsityDetector end
-struct FakeColoringAlgorithm <: ADTypes.AbstractColoringAlgorithm end
-
-function every_ad()
-    return [
-        AutoChainRules(; ruleconfig = :rc),
-        AutoDiffractor(),
-        AutoEnzyme(),
-        AutoFastDifferentiation(),
-        AutoFiniteDiff(),
-        AutoFiniteDifferences(; fdm = :fdm),
-        AutoForwardDiff(),
-        AutoGTPSA(),
-        AutoHyperHessians(),
-        AutoPolyesterForwardDiff(),
-        AutoReverseDiff(),
-        AutoSymbolics(),
-        AutoTapir(),
-        AutoTracker(),
-        AutoZygote(),
-    ]
-end
-
-function every_ad_with_options()
-    return [
-        AutoChainRules(; ruleconfig = :rc),
-        AutoDiffractor(),
-        AutoEnzyme(),
-        AutoEnzyme(mode = :forward),
-        AutoFastDifferentiation(),
-        AutoFiniteDiff(),
-        AutoFiniteDiff(
-            fdtype = :fd, fdjtype = :fdj, fdhtype = :fdh,
-            relstep = 1, absstep = 2, dir = false
-        ),
-        AutoFiniteDifferences(; fdm = :fdm),
-        AutoForwardDiff(),
-        AutoForwardDiff(chunksize = 3, tag = :tag),
-        AutoGTPSA(),
-        AutoGTPSA(descriptor = Val(:descriptor)),
-        AutoHyperHessians(),
-        AutoHyperHessians(chunksize = 8),
-        AutoMooncake(; config = :config),
-        AutoMooncakeForward(; config = :config),
-        AutoPolyesterForwardDiff(),
-        AutoPolyesterForwardDiff(chunksize = 3, tag = :tag),
-        AutoReverseDiff(),
-        AutoReverseDiff(compile = true),
-        AutoSymbolics(),
-        AutoTapir(),
-        AutoTapir(safe_mode = false),
-        AutoTracker(),
-        AutoZygote(),
-    ]
-end
-
-## Tests
-
-if GROUP == "All" || GROUP == "Core"
-    @testset verbose = true "ADTypes.jl" begin
-        @testset "Dense" begin
-            include("dense.jl")
+run_tests(;
+    core = function ()
+        @safetestset "Dense" include("dense.jl")
+        @safetestset "Sparse" include("sparse.jl")
+        @safetestset "Symbols" include("symbols.jl")
+        @safetestset "Legacy" include("legacy.jl")
+        @safetestset "Miscellaneous" include("misc.jl")
+        return if VERSION >= v"1.11.0-DEV.469"
+            @safetestset "Public" include("public.jl")
         end
-        @testset "Sparse" begin
-            include("sparse.jl")
-        end
-        @testset "Symbols" begin
-            include("symbols.jl")
-        end
-        @testset "Legacy" begin
-            include("legacy.jl")
-        end
-        @testset "Miscellaneous" begin
-            include("misc.jl")
-        end
-        if VERSION >= v"1.11.0-DEV.469"
-            @testset "Public" begin
-                include("public.jl")
-            end
-        end
-    end
-end
-
-if GROUP == "QA"
-    activate_qa_env()
-    @testset "Quality Assurance" begin
-        include(joinpath(@__DIR__, "qa", "qa.jl"))
-    end
-end
+    end,
+    qa = (;
+        env = joinpath(@__DIR__, "qa"),
+        body = joinpath(@__DIR__, "qa", "qa.jl")
+    ),
+)

--- a/test/shared/test_setup.jl
+++ b/test/shared/test_setup.jl
@@ -1,0 +1,86 @@
+using ADTypes
+using ADTypes: AbstractADType,
+    mode,
+    ForwardMode,
+    ForwardOrReverseMode,
+    ReverseMode,
+    SymbolicMode
+using ADTypes: dense_ad,
+    NoSparsityDetector,
+    KnownJacobianSparsityDetector,
+    KnownHessianSparsityDetector,
+    sparsity_detector,
+    jacobian_sparsity,
+    hessian_sparsity,
+    NoColoringAlgorithm,
+    coloring_algorithm,
+    column_coloring,
+    row_coloring,
+    symmetric_coloring
+using ChainRulesCore: ChainRulesCore, RuleConfig,
+    HasForwardsMode, HasReverseMode,
+    NoForwardsMode, NoReverseMode
+using EnzymeCore: EnzymeCore
+using Test
+
+struct CustomTag end
+
+struct ForwardRuleConfig <: RuleConfig{Union{HasForwardsMode, NoReverseMode}} end
+struct ReverseRuleConfig <: RuleConfig{Union{NoForwardsMode, HasReverseMode}} end
+struct ForwardOrReverseRuleConfig <: RuleConfig{Union{HasForwardsMode, HasReverseMode}} end
+
+struct FakeSparsityDetector <: ADTypes.AbstractSparsityDetector end
+struct FakeColoringAlgorithm <: ADTypes.AbstractColoringAlgorithm end
+
+function every_ad()
+    return [
+        AutoChainRules(; ruleconfig = :rc),
+        AutoDiffractor(),
+        AutoEnzyme(),
+        AutoFastDifferentiation(),
+        AutoFiniteDiff(),
+        AutoFiniteDifferences(; fdm = :fdm),
+        AutoForwardDiff(),
+        AutoGTPSA(),
+        AutoHyperHessians(),
+        AutoPolyesterForwardDiff(),
+        AutoReverseDiff(),
+        AutoSymbolics(),
+        AutoTapir(),
+        AutoTracker(),
+        AutoZygote(),
+    ]
+end
+
+function every_ad_with_options()
+    return [
+        AutoChainRules(; ruleconfig = :rc),
+        AutoDiffractor(),
+        AutoEnzyme(),
+        AutoEnzyme(mode = :forward),
+        AutoFastDifferentiation(),
+        AutoFiniteDiff(),
+        AutoFiniteDiff(
+            fdtype = :fd, fdjtype = :fdj, fdhtype = :fdh,
+            relstep = 1, absstep = 2, dir = false
+        ),
+        AutoFiniteDifferences(; fdm = :fdm),
+        AutoForwardDiff(),
+        AutoForwardDiff(chunksize = 3, tag = :tag),
+        AutoGTPSA(),
+        AutoGTPSA(descriptor = Val(:descriptor)),
+        AutoHyperHessians(),
+        AutoHyperHessians(chunksize = 8),
+        AutoMooncake(; config = :config),
+        AutoMooncakeForward(; config = :config),
+        AutoPolyesterForwardDiff(),
+        AutoPolyesterForwardDiff(chunksize = 3, tag = :tag),
+        AutoReverseDiff(),
+        AutoReverseDiff(compile = true),
+        AutoSymbolics(),
+        AutoTapir(),
+        AutoTapir(safe_mode = false),
+        AutoTracker(),
+        AutoZygote(),
+    ]
+end

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "shared", "test_setup.jl"))
+
 @testset "Subtyping" begin
     for ad in every_ad()
         sparse_ad = AutoSparse(ad)


### PR DESCRIPTION
Converts `test/runtests.jl` to the SciMLTesting v1.2 `run_tests` dispatcher (folder model).

- Core test files are made self-contained: the shared helper definitions previously inlined in `runtests.jl` (`every_ad`, `every_ad_with_options`, the `RuleConfig` subtypes, `CustomTag`, the fake sparsity/coloring detectors, and the `using` lines) are extracted to `test/shared/test_setup.jl`, which each Core file `include`s. `test/shared/` is the sanctioned non-group bucket, so it is never auto-discovered as a test.
- QA runs in its existing `test/qa/` sub-env.
- The `public.jl` version guard (`VERSION >= v"1.11.0-DEV.469"`) is preserved via an explicit-args `core` thunk. Folder-discovery cannot express a per-file version guard, and `public.jl` must NOT run on the LTS (1.10) matrix entry (`names(ADTypes)` does not return `public` symbols before 1.11, so the assertion would fail).
- `using ADTypes` is kept at top level (Main) because the printing tests qualify type modules via `Base.active_module()`.
- Deps: added `SciMLTesting` and `SafeTestsets` to the root `[extras]`/`[targets].test`/`[compat]` and to `test/qa/Project.toml`; dropped `Pkg` from the root test deps (no longer used by the harness). `test/test_groups.toml` unchanged.

Verified locally (`Pkg.test`): GROUP=Core passes on Julia 1.11 (6 testsets, incl. Public) and on 1.10 LTS (5 testsets, Public correctly skipped); GROUP=QA passes on 1.11 (11/11, exercising the sub-env activation path).

Supersedes #158 (the @safetestset canonicalization), which is folded into this PR.

Ignore until reviewed by @ChrisRackauckas.
