### PR TITLE
Fix docs reusable workflow permissions

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -14,5 +14,9 @@ concurrency:
 jobs:
   build-and-deploy-docs:
     name: "Documentation"
+    permissions:
+      actions: write
+      contents: write
+      statuses: write
     uses: "SciML/.github/.github/workflows/documentation.yml@v1"
     secrets: "inherit"


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Grant the Documentation reusable workflow the exact GITHUB_TOKEN permissions it requests: `actions: write`, `contents: write`, and `statuses: write`.
- This fixes the current `startup_failure` where GitHub rejects the reusable workflow before creating jobs because ADTypes defaults only allow `actions: none`, `contents: read`, and `statuses: none`.

## Evidence
- Latest failing run on `main`: https://github.com/SciML/ADTypes.jl/actions/runs/29395380694
- First observed failing run on `main`: https://github.com/SciML/ADTypes.jl/actions/runs/27995943944
- Last successful `main` run before the reusable workflow permission change: https://github.com/SciML/ADTypes.jl/actions/runs/27516101264
- Pre-amend fix verification run on the same tree: https://github.com/SciML/ADTypes.jl/actions/runs/29403974015
- Current post-amend Documentation run: https://github.com/SciML/ADTypes.jl/actions/runs/29406735319
- GitHub docs state that permissions passed from the caller workflow can only be maintained or reduced by the called workflow, not elevated.

## Local validation
- `actionlint`
- `actionlint .github/workflows/Documentation.yml`
- `git diff --check`
- `Runic.main(["--check", "."])` in a temporary local environment
- `timeout 3600 julia --project=. -e "using Pkg; Pkg.test()"`

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>