### PR TITLE
Require Setfield 1 for tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ ConstructionBase = "1.5"
 EnzymeCore = "0.5.3,0.6,0.7,0.8"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "2.4"
+Setfield = "1"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
> This draft PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- require Setfield 1 for the test-only `Setfield` extra
- keep the existing `@set!` compatibility tests as the regression coverage

## Root cause

`Setfield` was listed in `[extras]` and `[targets].test` without a compat entry. The strict old-style-extras downgrade resolution therefore selected Setfield 0.2.0, which does not export `@set!`; `test/misc.jl` then errored at its existing Setfield compatibility test.

Setfield 1.0.0 was verified directly to export and execute `@set!`. Requiring the stable 1.x line removes the stale 0.x test range without changing ADTypes runtime dependencies or public API.

## Validation

- Julia 1.12.6, current graph, `GROUP=Core Pkg.test()`: 507 passed, 0 failed/errors
- Julia 1.10.11, `julia-downgrade-compat@fab1def`, locked promoted-extras graph: Setfield 1.0.0 loaded; 506 passed, 0 failed/errors; manifest SHA-256 remained `2db43da5bba3a6a819221744b1fc7395e11f0d063f94e5d0e3be513c9e5c91d4`
- Julia 1.10.11 direct Setfield 1.0.0 API probe: `@set!` exported and executed successfully
- Runic 1.7.0 repository check: passed
- `git diff --check`: passed
