### PR TITLE
Require the public EnzymeCore 0.9 mode API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ ADTypesEnzymeCoreExt = "EnzymeCore"
 [compat]
 ChainRulesCore = "1.0.2"
 ConstructionBase = "1.5"
-EnzymeCore = "0.5.3,0.6,0.7,0.8,0.9"
+EnzymeCore = "0.9"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "2.4"
 Setfield = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ ADTypesEnzymeCoreExt = "EnzymeCore"
 [compat]
 ChainRulesCore = "1.0.2"
 ConstructionBase = "1.5"
-EnzymeCore = "0.5.3,0.6,0.7,0.8"
+EnzymeCore = "0.5.3,0.6,0.7,0.8,0.9"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "2.4"
 Setfield = "1"

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -60,7 +60,7 @@ Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
 
   - `mode::M` determines the autodiff mode (forward or reverse). It can be:
 
-      + an object subtyping `EnzymeCore.Mode` (like `EnzymeCore.Forward` or `EnzymeCore.Reverse`) if a specific mode is required
+      + a mode value like `EnzymeCore.Forward` or `EnzymeCore.Reverse` if a specific mode is required
       + `nothing` to choose the best mode automatically
 """
 struct AutoEnzyme{M, A} <: AbstractADType

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -28,6 +28,11 @@ end
 end
 
 @testset "AutoEnzyme" begin
+    if pkgversion(EnzymeCore) >= v"0.9"
+        @test :ForwardMode in names(EnzymeCore)
+        @test :ReverseMode in names(EnzymeCore)
+    end
+
     ad = AutoEnzyme()
     @test ad isa AbstractADType
     @test ad isa AutoEnzyme{Nothing, Nothing}

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -28,10 +28,8 @@ end
 end
 
 @testset "AutoEnzyme" begin
-    if pkgversion(EnzymeCore) >= v"0.9"
-        @test :ForwardMode in names(EnzymeCore)
-        @test :ReverseMode in names(EnzymeCore)
-    end
+    @test :ForwardMode in names(EnzymeCore)
+    @test :ReverseMode in names(EnzymeCore)
 
     ad = AutoEnzyme()
     @test ad isa AbstractADType
@@ -44,6 +42,9 @@ end
     @test ad isa AutoEnzyme{typeof(EnzymeCore.Forward), Nothing}
     @test mode(ad) isa ForwardMode
     @test ad.mode == EnzymeCore.Forward
+
+    ad = AutoEnzyme(; mode = EnzymeCore.ForwardWithPrimal)
+    @test mode(ad) isa ForwardMode
 
     ad = AutoEnzyme(; function_annotation = EnzymeCore.Const)
     @test ad isa AbstractADType
@@ -58,6 +59,9 @@ end
     @test ad isa AutoEnzyme{typeof(EnzymeCore.Reverse), EnzymeCore.Duplicated}
     @test mode(ad) isa ReverseMode
     @test ad.mode == EnzymeCore.Reverse
+
+    ad = AutoEnzyme(; mode = EnzymeCore.ReverseHolomorphicWithPrimal)
+    @test mode(ad) isa ReverseMode
 end
 
 @testset "AutoReactant" begin


### PR DESCRIPTION
Ignore this draft until it has been reviewed by @ChrisRackauckas.

## Summary

- require EnzymeCore 0.9, where the direction supertypes used by
  `ADTypesEnzymeCoreExt` are public and documented
- test forward and reverse classification with configured public mode values,
  not only the default `Forward` and `Reverse` values
- remove the public `AutoEnzyme` documentation's reference to the non-public
  `EnzymeCore.Mode` type

## Why EnzymeCore 0.9 is the floor

The extension dispatches on `EnzymeCore.ForwardMode` and
`EnzymeCore.ReverseMode`. EnzymeCore 0.5 through 0.8 do not expose those types,
or another complete direction classifier, as public API. Matching only a
finite list of exported mode values is not equivalent: configured, split, and
transformed modes have additional concrete types.

Keeping the older compatibility entries would therefore retain a dependency
on EnzymeCore internals. EnzymeCore 0.9 provides the required public nominal
contract, so this revision intentionally replaces the old range with `0.9`.

EnzymeCore 0.9 is not registered at the time of this draft. This PR must remain
a draft until the owner API is released and the compatibility/release sequence
has been reviewed.

## Validation

The local registry fixture used the exact EnzymeCore tree from Enzyme commit
`02d3ce42a45afa4939a3eed53b71c2690537e1a6` (EnzymeCore tree
`238a57ad8fa9887b674a4e4f2ebccb2698b28e06`):

- Julia 1.10.11, `GROUP=Core`: 510/510 passed
- Julia 1.10.11, `GROUP=QA`: 18/18 passed
- Julia 1.12.6, `GROUP=Core`: 511/511 passed
- EnzymeCore 0.8.21 rejection control: resolver reported the expected empty
  intersection with project compatibility `0.9`
- whole-repository Runic 1.7 check passed
- `git diff --check` passed
- seven metadata/public-contract assertions passed

No test was skipped, silenced, disabled, or weakened.

## Audit notes

The original draft head (`237dff7bc9abea91bbd800cbeb5ec18854063298`)
temporarily widened compatibility through 0.9. After its conservative one-hour
timer elapsed, all 11 hosted checks were complete and successful. A strict
public-API re-audit then found that preserving EnzymeCore 0.5-0.8 would preserve
the internal-type dependency, which led to the 0.9-only follow-up commit.

A first local QA attempt with a path-developed, unregistered EnzymeCore 0.9
correctly exposed a topology artifact: Pkg promoted the path-tracked weak
dependency into the isolated QA manifest, so Aqua reported it as stale. The
authoritative QA run used a workspace-local registry entry with the exact owner
tree, reproducing normal registered weak-dependency topology, and passed 18/18.

At the scheduled read of the revised hosted CI head, documentation, Runic,
spelling, and test detection passed. The Core, QA, and downgrade lanes all
stopped at dependency resolution because registered metadata does not yet
contain a compatible EnzymeCore 0.9 release; no package tests failed. This is
the expected draft-state blocker, and the compatibility floor was not weakened
to make those jobs resolve against the older non-public API.
