### PR TITLE
Use strict path-free QA defaults

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,9 @@ using ADTypes
 makedocs(
     sitename = "ADTypes",
     format = Documenter.HTML(),
-    modules = [ADTypes]
+    modules = [ADTypes],
+    doctest = true,
+    checkdocs = :exports,
 )
 
 deploydocs(

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -6,9 +6,6 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-ADTypes = {path = "../.."}
-
 [compat]
 ADTypes = "1"
 Aqua = "0.8"


### PR DESCRIPTION
## Summary
- remove the obsolete QA `[sources]` path
- enable Documentation doctests and exported API coverage

## Verification
- `julia +1.12 --project=. -e "using Pkg; Pkg.test()"` (507/507)
- strict SciMLTesting 2.4 QA environment
- doctest/export-check Documenter build
- Runic and `git diff --check`

Ignore until reviewed by @ChrisRackauckas.