### PR TITLE
Document ADTypes extension contracts

### DIFF
--- a/src/ADTypes.jl
+++ b/src/ADTypes.jl
@@ -11,6 +11,13 @@ using Base: @deprecate
     AbstractADType
 
 Abstract supertype for all AD choices.
+
+# Extension contract
+
+External packages may subtype `AbstractADType` to describe an AD backend. They must
+also implement [`mode`](@ref) for their concrete subtype and return an instance of
+an [`AbstractMode`](@ref) subtype. Consumers should dispatch on `mode(ad)`, rather
+than on a downstream concrete AD type.
 """
 abstract type AbstractADType end
 

--- a/src/mode.jl
+++ b/src/mode.jl
@@ -16,6 +16,12 @@ abstract type AbstractMode end
     mode(ad::AbstractADType)
 
 Return the differentiation mode of `ad`, as a subtype of [`AbstractMode`](@ref).
+
+# Extension contract
+
+Every external concrete subtype of [`AbstractADType`](@ref) must provide this
+method. Return an instance of the most specific applicable mode trait; callers may
+use that trait for dispatch but must not require a particular backend implementation.
 """
 function mode end
 

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -5,10 +5,15 @@
 
 Abstract supertype for sparsity pattern detectors.
 
-# Required methods
+# Extension contract
 
-  - [`jacobian_sparsity`](@ref)
-  - [`hessian_sparsity`](@ref)
+External detectors implement the supported public forms of
+[`jacobian_sparsity`](@ref) and/or [`hessian_sparsity`](@ref). A Jacobian pattern
+must be an `AbstractMatrix{Bool}` with shape `(length(y), length(x))`, where `y` is
+`f(x)` for the out-of-place form or the supplied output buffer for the in-place
+form. A Hessian pattern must be an `AbstractMatrix{Bool}` with shape
+`(length(x), length(x))`. Methods for unsupported operations must throw an error;
+they must not return an unrelated pattern.
 """
 abstract type AbstractSparsityDetector end
 
@@ -110,11 +115,14 @@ end
 
 Abstract supertype for Jacobian/Hessian coloring algorithms.
 
-# Required methods
+# Extension contract
 
-  - [`column_coloring`](@ref)
-  - [`row_coloring`](@ref)
-  - [`symmetric_coloring`](@ref)
+External algorithms implement the supported public coloring functions. Each result
+must be an `AbstractVector` of integers: column colorings have length `size(M, 2)`,
+row colorings have length `size(M, 1)`, and symmetric colorings require a square
+matrix and have length `size(M, 1)`. The assigned colors must satisfy the structural
+orthogonality condition documented by each coloring function. Unsupported coloring
+forms must throw an error.
 
 # Note
 

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -1,5 +1,38 @@
 include(joinpath(@__DIR__, "shared", "test_setup.jl"))
 
+struct ExternalADType <: AbstractADType end
+ADTypes.mode(::ExternalADType) = ForwardMode()
+
+struct ExternalSparsityDetector <: ADTypes.AbstractSparsityDetector end
+ADTypes.jacobian_sparsity(f, x, ::ExternalSparsityDetector) = trues(length(f(x)), length(x))
+ADTypes.jacobian_sparsity(f!, y, x, ::ExternalSparsityDetector) = trues(length(y), length(x))
+ADTypes.hessian_sparsity(f, x, ::ExternalSparsityDetector) = trues(length(x), length(x))
+
+struct ExternalColoringAlgorithm <: ADTypes.AbstractColoringAlgorithm end
+ADTypes.column_coloring(M, ::ExternalColoringAlgorithm) = 1:size(M, 2)
+ADTypes.row_coloring(M, ::ExternalColoringAlgorithm) = 1:size(M, 1)
+ADTypes.symmetric_coloring(M, ::ExternalColoringAlgorithm) = 1:size(M, 1)
+
+@testset "External public interface contracts" begin
+    ad = ExternalADType()
+    @test mode(ad) isa ForwardMode
+
+    x = rand(2)
+    y = similar(x)
+    f(x) = vcat(x, x)
+    f!(y, x) = y .= x
+    detector = ExternalSparsityDetector()
+    @test size(jacobian_sparsity(f, x, detector)) == (4, 2)
+    @test size(jacobian_sparsity(f!, y, x, detector)) == (2, 2)
+    @test size(hessian_sparsity(sum, x, detector)) == (2, 2)
+
+    colors = ExternalColoringAlgorithm()
+    M = trues(2, 3)
+    @test column_coloring(M, colors) == 1:3
+    @test row_coloring(M, colors) == 1:2
+    @test symmetric_coloring(trues(2, 2), colors) == 1:2
+end
+
 @testset "Subtyping" begin
     for ad in every_ad()
         sparse_ad = AutoSparse(ad)


### PR DESCRIPTION
## Summary
- document public extension rules for AD modes, sparsity detectors, and coloring algorithms
- add public-only downstream mock coverage for each generic interface

## Verification
- `Pkg.test("ADTypes"; test_args=["sparse"])`
- plain SciMLTesting strict QA: 20/20
- Documenter doctests, checkdocs, and HTML rendering
- Julia Runic `--check` and `git diff --check`

Ignore until reviewed by @ChrisRackauckas.