### PR TITLE
Document sparsity pattern element types instead of enforcing Bool

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ EnzymeCore = "0.5.3,0.6,0.7,0.8"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "2.4"
 Setfield = "1"
+SparseArrays = "1"
 julia = "1.10"
 
 [extras]
@@ -28,7 +29,8 @@ EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ChainRulesCore", "EnzymeCore", "SafeTestsets", "SciMLTesting", "Setfield", "Test"]
+test = ["ChainRulesCore", "EnzymeCore", "SafeTestsets", "SciMLTesting", "Setfield", "SparseArrays", "Test"]

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -14,6 +14,11 @@ must be an `AbstractMatrix{Bool}` with shape `(length(y), length(x))`, where `y`
 form. A Hessian pattern must be an `AbstractMatrix{Bool}` with shape
 `(length(x), length(x))`. Methods for unsupported operations must throw an error;
 they must not return an unrelated pattern.
+
+New detectors should return `Bool` patterns, but consumers should treat any nonzero
+entry as a structural nonzero: patterns with an integer element type are also
+accepted by [`KnownJacobianSparsityDetector`](@ref) and
+[`KnownHessianSparsityDetector`](@ref), and are handed back unchanged.
 """
 abstract type AbstractSparsityDetector end
 
@@ -52,12 +57,17 @@ hessian_sparsity(f, x, ::NoSparsityDetector) = trues(length(x), length(x))
 
 Trivial sparsity detector used to return a known Jacobian sparsity pattern.
 
+`AbstractMatrix{Bool}` is the recommended pattern type, but any integer element type
+is accepted, so that patterns expressed as matrices of ones and zeroes keep working.
+The pattern is returned by [`jacobian_sparsity`](@ref) unchanged, element type
+included. Non-integer element types (e.g. `Float64`) are rejected by the constructor.
+
 # See also
 
   - [`AbstractSparsityDetector`](@ref)
   - [`KnownHessianSparsityDetector`](@ref)
 """
-struct KnownJacobianSparsityDetector{J <: AbstractMatrix{Bool}} <: AbstractSparsityDetector
+struct KnownJacobianSparsityDetector{J <: AbstractMatrix{<:Integer}} <: AbstractSparsityDetector
     jacobian_sparsity::J
 end
 
@@ -84,12 +94,17 @@ end
 
 Trivial sparsity detector used to return a known Hessian sparsity pattern.
 
+`AbstractMatrix{Bool}` is the recommended pattern type, but any integer element type
+is accepted, so that patterns expressed as matrices of ones and zeroes keep working.
+The pattern is returned by [`hessian_sparsity`](@ref) unchanged, element type
+included. Non-integer element types (e.g. `Float64`) are rejected by the constructor.
+
 # See also
 
   - [`AbstractSparsityDetector`](@ref)
   - [`KnownJacobianSparsityDetector`](@ref)
 """
-struct KnownHessianSparsityDetector{H <: AbstractMatrix{Bool}} <: AbstractSparsityDetector
+struct KnownHessianSparsityDetector{H <: AbstractMatrix{<:Integer}} <: AbstractSparsityDetector
     hessian_sparsity::H
 end
 

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -15,10 +15,18 @@ form. A Hessian pattern must be an `AbstractMatrix{Bool}` with shape
 `(length(x), length(x))`. Methods for unsupported operations must throw an error;
 they must not return an unrelated pattern.
 
-New detectors should return `Bool` patterns, but consumers should treat any nonzero
-entry as a structural nonzero: patterns with an integer element type are also
-accepted by [`KnownJacobianSparsityDetector`](@ref) and
-[`KnownHessianSparsityDetector`](@ref), and are handed back unchanged.
+New detectors should return `Bool` patterns, but consumers must not require `Bool`:
+they should treat every nonzero entry as a structural nonzero. Patterns given as
+integer or floating point matrices of ones and zeroes are common in the wild, are
+accepted unchanged by [`KnownJacobianSparsityDetector`](@ref) and
+[`KnownHessianSparsityDetector`](@ref), and are handled correctly by the coloring
+and decompression implementations used downstream (SparseMatrixColorings.jl through
+DifferentiationInterface.jl). The element type of the pattern does not propagate to
+the differentiation result.
+
+For a sparse matrix, the stored structure defines the pattern: an explicitly stored
+zero is treated as a structural nonzero, which yields a valid but more conservative
+coloring than the same matrix passed through `dropzeros`.
 """
 abstract type AbstractSparsityDetector end
 
@@ -53,21 +61,22 @@ jacobian_sparsity(f!, y, x, ::NoSparsityDetector) = trues(length(y), length(x))
 hessian_sparsity(f, x, ::NoSparsityDetector) = trues(length(x), length(x))
 
 """
-    KnownJacobianSparsityDetector(jacobian_sparsity::AbstractMatrix{Bool}) <: AbstractSparsityDetector
+    KnownJacobianSparsityDetector(jacobian_sparsity::AbstractMatrix) <: AbstractSparsityDetector
 
 Trivial sparsity detector used to return a known Jacobian sparsity pattern.
 
-`AbstractMatrix{Bool}` is the recommended pattern type, but any integer element type
-is accepted, so that patterns expressed as matrices of ones and zeroes keep working.
-The pattern is returned by [`jacobian_sparsity`](@ref) unchanged, element type
-included. Non-integer element types (e.g. `Float64`) are rejected by the constructor.
+`AbstractMatrix{Bool}` is the canonical pattern type, but the element type is neither
+converted nor checked: [`jacobian_sparsity`](@ref) hands the pattern back exactly as
+given, and consumers treat every nonzero entry as a structural nonzero, so integer or
+floating point matrices of ones and zeroes work as well (see the extension contract of
+[`AbstractSparsityDetector`](@ref)).
 
 # See also
 
   - [`AbstractSparsityDetector`](@ref)
   - [`KnownHessianSparsityDetector`](@ref)
 """
-struct KnownJacobianSparsityDetector{J <: AbstractMatrix{<:Integer}} <: AbstractSparsityDetector
+struct KnownJacobianSparsityDetector{J <: AbstractMatrix} <: AbstractSparsityDetector
     jacobian_sparsity::J
 end
 
@@ -90,21 +99,22 @@ function hessian_sparsity(f, x, sd::KnownJacobianSparsityDetector)
 end
 
 """
-    KnownHessianSparsityDetector(hessian_sparsity::AbstractMatrix{Bool}) <: AbstractSparsityDetector
+    KnownHessianSparsityDetector(hessian_sparsity::AbstractMatrix) <: AbstractSparsityDetector
 
 Trivial sparsity detector used to return a known Hessian sparsity pattern.
 
-`AbstractMatrix{Bool}` is the recommended pattern type, but any integer element type
-is accepted, so that patterns expressed as matrices of ones and zeroes keep working.
-The pattern is returned by [`hessian_sparsity`](@ref) unchanged, element type
-included. Non-integer element types (e.g. `Float64`) are rejected by the constructor.
+`AbstractMatrix{Bool}` is the canonical pattern type, but the element type is neither
+converted nor checked: [`hessian_sparsity`](@ref) hands the pattern back exactly as
+given, and consumers treat every nonzero entry as a structural nonzero, so integer or
+floating point matrices of ones and zeroes work as well (see the extension contract of
+[`AbstractSparsityDetector`](@ref)).
 
 # See also
 
   - [`AbstractSparsityDetector`](@ref)
   - [`KnownJacobianSparsityDetector`](@ref)
 """
-struct KnownHessianSparsityDetector{H <: AbstractMatrix{<:Integer}} <: AbstractSparsityDetector
+struct KnownHessianSparsityDetector{H <: AbstractMatrix} <: AbstractSparsityDetector
     hessian_sparsity::H
 end
 

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -48,7 +48,7 @@ jacobian_sparsity(f!, y, x, ::NoSparsityDetector) = trues(length(y), length(x))
 hessian_sparsity(f, x, ::NoSparsityDetector) = trues(length(x), length(x))
 
 """
-    KnownJacobianSparsityDetector(jacobian_sparsity::AbstractMatrix) <: AbstractSparsityDetector
+    KnownJacobianSparsityDetector(jacobian_sparsity::AbstractMatrix{Bool}) <: AbstractSparsityDetector
 
 Trivial sparsity detector used to return a known Jacobian sparsity pattern.
 
@@ -57,7 +57,7 @@ Trivial sparsity detector used to return a known Jacobian sparsity pattern.
   - [`AbstractSparsityDetector`](@ref)
   - [`KnownHessianSparsityDetector`](@ref)
 """
-struct KnownJacobianSparsityDetector{J <: AbstractMatrix} <: AbstractSparsityDetector
+struct KnownJacobianSparsityDetector{J <: AbstractMatrix{Bool}} <: AbstractSparsityDetector
     jacobian_sparsity::J
 end
 
@@ -80,7 +80,7 @@ function hessian_sparsity(f, x, sd::KnownJacobianSparsityDetector)
 end
 
 """
-    KnownHessianSparsityDetector(hessian_sparsity::AbstractMatrix) <: AbstractSparsityDetector
+    KnownHessianSparsityDetector(hessian_sparsity::AbstractMatrix{Bool}) <: AbstractSparsityDetector
 
 Trivial sparsity detector used to return a known Hessian sparsity pattern.
 
@@ -89,7 +89,7 @@ Trivial sparsity detector used to return a known Hessian sparsity pattern.
   - [`AbstractSparsityDetector`](@ref)
   - [`KnownJacobianSparsityDetector`](@ref)
 """
-struct KnownHessianSparsityDetector{H <: AbstractMatrix} <: AbstractSparsityDetector
+struct KnownHessianSparsityDetector{H <: AbstractMatrix{Bool}} <: AbstractSparsityDetector
     hessian_sparsity::H
 end
 
@@ -133,7 +133,7 @@ The terminology and definitions are taken from the following paper:
 abstract type AbstractColoringAlgorithm end
 
 """
-    column_coloring(M::AbstractMatrix, ca::ColoringAlgorithm)::AbstractVector{<:Integer}
+    column_coloring(M::AbstractMatrix, ca::AbstractColoringAlgorithm)::AbstractVector{<:Integer}
 
 Use algorithm `ca` to construct a structurally orthogonal partition of the columns of `M`.
 
@@ -142,7 +142,7 @@ The result is a coloring vector `c` of length `size(M, 2)` such that for every n
 function column_coloring end
 
 """
-    row_coloring(M::AbstractMatrix, ca::ColoringAlgorithm)::AbstractVector{<:Integer}
+    row_coloring(M::AbstractMatrix, ca::AbstractColoringAlgorithm)::AbstractVector{<:Integer}
 
 Use algorithm `ca` to construct a structurally orthogonal partition of the rows of `M`.
 
@@ -151,7 +151,7 @@ The result is a coloring vector `c` of length `size(M, 1)` such that for every n
 function row_coloring end
 
 """
-    symmetric_coloring(M::AbstractMatrix, ca::ColoringAlgorithm)::AbstractVector{<:Integer}
+    symmetric_coloring(M::AbstractMatrix, ca::AbstractColoringAlgorithm)::AbstractVector{<:Integer}
 
 Use algorithm `ca` to construct a symmetrically structurally orthogonal partition of the columns (or rows) of the symmetric matrix `M`.
 

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -1,5 +1,7 @@
 include(joinpath(@__DIR__, "shared", "test_setup.jl"))
 
+using SparseArrays: sparse
+
 struct ExternalADType <: AbstractADType end
 ADTypes.mode(::ExternalADType) = ForwardMode()
 
@@ -89,17 +91,22 @@ end
 
     @testset "KnownJacobianSparsityDetector" begin
         @testset "Pattern element types" begin
+            # Consumers treat any nonzero entry as a structural nonzero, so patterns
+            # written as integer or float ones and zeroes are stored and returned as-is.
             Jbool = rand(Bool, 4, 2)
             x = rand(2)
             y = rand(4)
-            for J in (Jbool, BitMatrix(Jbool), Int.(Jbool), UInt8.(Jbool), Int32.(Jbool))
+            for J in (
+                    Jbool, BitMatrix(Jbool), Int.(Jbool), UInt8.(Jbool),
+                    Float64.(Jbool), Float32.(Jbool), sparse(Float64.(Jbool)),
+                    Any[Int(v) for v in Jbool],
+                )
                 sd = KnownJacobianSparsityDetector(J)
+                @test sd isa KnownJacobianSparsityDetector{typeof(J)}
                 @test jacobian_sparsity(f_jac1, x, sd) === J
                 @test jacobian_sparsity(f_jac!, y, x, sd) === J
                 @test eltype(jacobian_sparsity(f_jac1, x, sd)) === eltype(J)
             end
-            @test_throws MethodError KnownJacobianSparsityDetector(Float64.(Jbool))
-            @test_throws MethodError KnownJacobianSparsityDetector(Any[1 0; 0 1])
         end
 
         @testset "Jacobian sparsity detection" begin
@@ -141,7 +148,7 @@ end
         end
         @testset "Exceptions: DimensionMismatch" begin
             # wrong Jacobian size
-            for J in (rand(Bool, 6, 7), Int.(rand(Bool, 6, 7)))
+            for J in (rand(Bool, 6, 7), Int.(rand(Bool, 6, 7)), Float64.(rand(Bool, 6, 7)))
                 sd = KnownJacobianSparsityDetector(J)
                 for x in (rand(2), rand(2, 3)), f in (f_jac1, f_jac2)
 
@@ -159,13 +166,16 @@ end
         @testset "Pattern element types" begin
             Hbool = rand(Bool, 2, 2)
             x = rand(2)
-            for H in (Hbool, BitMatrix(Hbool), Int.(Hbool), UInt8.(Hbool), Int32.(Hbool))
+            for H in (
+                    Hbool, BitMatrix(Hbool), Int.(Hbool), UInt8.(Hbool),
+                    Float64.(Hbool), Float32.(Hbool), sparse(Float64.(Hbool)),
+                    Any[Int(v) for v in Hbool],
+                )
                 sd = KnownHessianSparsityDetector(H)
+                @test sd isa KnownHessianSparsityDetector{typeof(H)}
                 @test hessian_sparsity(f_hess, x, sd) === H
                 @test eltype(hessian_sparsity(f_hess, x, sd)) === eltype(H)
             end
-            @test_throws MethodError KnownHessianSparsityDetector(Float64.(Hbool))
-            @test_throws MethodError KnownHessianSparsityDetector(Any[1 0; 0 1])
         end
 
         @testset "Hessian sparsity detection" begin
@@ -205,7 +215,7 @@ end
         end
         @testset "Exceptions: DimensionMismatch" begin
             # wrong Hessian size
-            for H in (rand(Bool, 2, 3), Int.(rand(Bool, 2, 3)))
+            for H in (rand(Bool, 2, 3), Int.(rand(Bool, 2, 3)), Float64.(rand(Bool, 2, 3)))
                 sd = KnownHessianSparsityDetector(H)
                 for x in (rand(2), rand(2, 3))
                     @test_throws DimensionMismatch hessian_sparsity(f_hess, x, sd)

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -88,6 +88,8 @@ end
     end
 
     @testset "KnownJacobianSparsityDetector" begin
+        @test_throws MethodError KnownJacobianSparsityDetector(rand(2, 2))
+
         @testset "Jacobian sparsity detection" begin
             @testset "Out-of-place functions" begin
                 for sx in ((2,), (2, 3)), f in (f_jac1, f_jac2)
@@ -139,6 +141,8 @@ end
     end
 
     @testset "KnownHessianSparsityDetector" begin
+        @test_throws MethodError KnownHessianSparsityDetector(rand(2, 2))
+
         @testset "Hessian sparsity detection" begin
             for sx in ((2,), (2, 3))
                 x = rand(sx...)

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -88,7 +88,19 @@ end
     end
 
     @testset "KnownJacobianSparsityDetector" begin
-        @test_throws MethodError KnownJacobianSparsityDetector(rand(2, 2))
+        @testset "Pattern element types" begin
+            Jbool = rand(Bool, 4, 2)
+            x = rand(2)
+            y = rand(4)
+            for J in (Jbool, BitMatrix(Jbool), Int.(Jbool), UInt8.(Jbool), Int32.(Jbool))
+                sd = KnownJacobianSparsityDetector(J)
+                @test jacobian_sparsity(f_jac1, x, sd) === J
+                @test jacobian_sparsity(f_jac!, y, x, sd) === J
+                @test eltype(jacobian_sparsity(f_jac1, x, sd)) === eltype(J)
+            end
+            @test_throws MethodError KnownJacobianSparsityDetector(Float64.(Jbool))
+            @test_throws MethodError KnownJacobianSparsityDetector(Any[1 0; 0 1])
+        end
 
         @testset "Jacobian sparsity detection" begin
             @testset "Out-of-place functions" begin
@@ -128,20 +140,33 @@ end
             end
         end
         @testset "Exceptions: DimensionMismatch" begin
-            sd = KnownJacobianSparsityDetector(rand(Bool, 6, 7)) # wrong Jacobian size
-            for x in (rand(2), rand(2, 3)), f in (f_jac1, f_jac2)
+            # wrong Jacobian size
+            for J in (rand(Bool, 6, 7), Int.(rand(Bool, 6, 7)))
+                sd = KnownJacobianSparsityDetector(J)
+                for x in (rand(2), rand(2, 3)), f in (f_jac1, f_jac2)
 
-                @test_throws DimensionMismatch jacobian_sparsity(f, x, sd)
-            end
-            for x in (rand(2), rand(2, 3)), y in (rand(5), rand(5, 6))
+                    @test_throws DimensionMismatch jacobian_sparsity(f, x, sd)
+                end
+                for x in (rand(2), rand(2, 3)), y in (rand(5), rand(5, 6))
 
-                @test_throws DimensionMismatch jacobian_sparsity(f_jac!, y, x, sd)
+                    @test_throws DimensionMismatch jacobian_sparsity(f_jac!, y, x, sd)
+                end
             end
         end
     end
 
     @testset "KnownHessianSparsityDetector" begin
-        @test_throws MethodError KnownHessianSparsityDetector(rand(2, 2))
+        @testset "Pattern element types" begin
+            Hbool = rand(Bool, 2, 2)
+            x = rand(2)
+            for H in (Hbool, BitMatrix(Hbool), Int.(Hbool), UInt8.(Hbool), Int32.(Hbool))
+                sd = KnownHessianSparsityDetector(H)
+                @test hessian_sparsity(f_hess, x, sd) === H
+                @test eltype(hessian_sparsity(f_hess, x, sd)) === eltype(H)
+            end
+            @test_throws MethodError KnownHessianSparsityDetector(Float64.(Hbool))
+            @test_throws MethodError KnownHessianSparsityDetector(Any[1 0; 0 1])
+        end
 
         @testset "Hessian sparsity detection" begin
             for sx in ((2,), (2, 3))
@@ -179,9 +204,12 @@ end
             end
         end
         @testset "Exceptions: DimensionMismatch" begin
-            sd = KnownHessianSparsityDetector(rand(Bool, 2, 3)) #wrong Hessian size
-            for x in (rand(2), rand(2, 3))
-                @test_throws DimensionMismatch hessian_sparsity(f_hess, x, sd)
+            # wrong Hessian size
+            for H in (rand(Bool, 2, 3), Int.(rand(Bool, 2, 3)))
+                sd = KnownHessianSparsityDetector(H)
+                for x in (rand(2), rand(2, 3))
+                    @test_throws DimensionMismatch hessian_sparsity(f_hess, x, sd)
+                end
             end
         end
     end


### PR DESCRIPTION
## Summary

Tested float (and other) known sparsity patterns end to end against DifferentiationInterface.jl + SparseMatrixColorings.jl. They all work, so this PR no longer enforces anything — the type restriction is dropped and the observed contract is documented and tested instead. No behavior change, no breaking change.

- document in the `AbstractSparsityDetector` extension contract that consumers must treat every nonzero entry as a structural nonzero rather than requiring `Bool`, that the pattern element type does not propagate to the differentiation result, and that for sparse matrices the *stored* structure defines the pattern (an explicitly stored zero counts as a structural nonzero and gives a valid but more conservative coloring)
- document in both `Known*SparsityDetector` docstrings that `AbstractMatrix{Bool}` is canonical but the element type is neither converted nor checked, and the pattern is handed back exactly as given
- test the pattern element types: `Bool`, `BitMatrix`, `Int`, `UInt8`, `Float64`, `Float32`, `SparseMatrixCSC{Float64}`, `Matrix{Any}` — construction, identity round-trip through `jacobian_sparsity`/`hessian_sparsity`, and `DimensionMismatch` for `Bool`/`Int`/`Float64` patterns
- correct coloring API docstrings to reference `AbstractColoringAlgorithm`
- add `SparseArrays` as a test dependency (for the sparse pattern case)

## Downstream evidence (ADTypes dev from this branch, DI 0.7.20, SparseMatrixColorings 0.4.27)

`AutoSparse(AutoForwardDiff(); sparsity_detector=Known*SparsityDetector(S), coloring_algorithm=GreedyColoringAlgorithm())`, comparing against the dense ForwardDiff result:

```
--- KnownJacobianSparsityDetector through DI.jacobian / DI.jacobian (in-place f!) ---
Matrix{Bool}               -> CORRECT  eltype=Float64
BitMatrix                  -> CORRECT  eltype=Float64
Matrix{Int}                -> CORRECT  eltype=Float64
Matrix{UInt8}              -> CORRECT  eltype=Float64
Matrix{Float64}            -> CORRECT  eltype=Float64
Matrix{Float32}            -> CORRECT  eltype=Float64
SparseMatrixCSC{Bool}      -> CORRECT  eltype=Float64
SparseMatrixCSC{Float64}   -> CORRECT  eltype=Float64
Matrix{Any}                -> CORRECT  eltype=Float64

--- KnownHessianSparsityDetector through DI.hessian ---   (same nine cases, all CORRECT)

--- pattern element type does not leak into the result ---
pattern eltype Bool/Int64/Float32/Float64 -> result eltype Float64

--- sparse pattern with an explicitly stored zero ---
stored zero: correct=true colors=[1, 2, 3]
dropzeros:   correct=true colors=[1, 1, 2]
```

Also probed with a custom detector on registered ADTypes 1.22.3: float patterns with non-0/1 values, negative values, a `NaN` entry, `Complex{Float64}`, and `Union{Missing,Bool}` all produce correct Jacobians. The only failure found is an element type with no `zero`/`iszero` (`Matrix{String}` → `MethodError: no method matching zero(::String)`), which fails in the consumer regardless of what ADTypes accepts.

## Validation
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` → all groups pass (`Sparse | 268 268`)
- `GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` → `QA | 20 20`
- `julia +1.12 --project=docs docs/make.jl` → no doc warnings/errors
- Runic `--check src test` → exit 0

Ignore until reviewed by @ChrisRackauckas.