### PR TITLE
Assert ADTypes' extensions actually loaded in the QA group

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -7,6 +7,14 @@ using JET
 # `Base.get_extension` returns `nothing` and every extension is silently skipped.
 using ChainRulesCore, ConstructionBase, EnzymeCore
 
+# ExplicitImports silently skips an extension that fails to load, so assert the
+# extension modules actually exist rather than trusting a green run_qa.
+@testset "Extensions loaded" begin
+    for ext in (:ADTypesChainRulesCoreExt, :ADTypesConstructionBaseExt, :ADTypesEnzymeCoreExt)
+        @test Base.get_extension(ADTypes, ext) !== nothing
+    end
+end
+
 # Aqua and ExplicitImports are SciMLTesting deps, so they are not imported here.
 # Aqua is still listed in this env's `[deps]` (not ExplicitImports): Aqua's ambiguity
 # check spawns a worker subprocess that runs a bare `using Aqua` against the active


### PR DESCRIPTION
Follow-up to #173, which landed before this could be folded in.

## Problem

#173 made the QA group load the weakdeps so ExplicitImports would scan `ext/`. But the
mechanism that made the extensions invisible in the first place is a *silent* skip:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

A missing extension module is skipped, not reported. So a green `run_qa` is not
evidence that anything in `ext/` was actually checked. If an extension's precompilation
later breaks, or a weakdep gets dropped from `test/qa/Project.toml`, QA stays green
while extension coverage silently drops back to zero — which is exactly the state #173
set out to fix, restored without anyone noticing.

## Fix

Assert the extension modules exist before `run_qa`, so a load failure fails QA loudly
instead of quietly shrinking the scanned set:

```julia
@testset "Extensions loaded" begin
    for ext in (:ADTypesChainRulesCoreExt, :ADTypesConstructionBaseExt, :ADTypesEnzymeCoreExt)
        @test Base.get_extension(ADTypes, ext) !== nothing
    end
end
```

Confirmed the guard is load-bearing rather than decorative: running the same block with
`EnzymeCore` deliberately not loaded fails as intended.

```
Test Summary:     | Pass  Fail  Total  Time
Extensions loaded |    2     1      3  2.9s
ERROR: Some tests did not pass: 2 passed, 1 failed, 0 errored, 0 broken.
```

## Local QA result

`GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'` on this branch (Julia 1.12):

```
Test Summary: | Pass  Total   Time
QA            |   23     23  45.0s
     Testing ADTypes tests passed
```

23 vs. 20 on current `main` — the three added passes are the three extension assertions.
Test-only change; no `src/` or `ext/` code is touched.

---

This PR should be ignored until reviewed by @ChrisRackauckas.
