### PR TITLE
AutoHyperHessians: add simd and jet options for HyperHessians 0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ADTypes"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors"]
-version = "1.22.4"
+version = "1.23.0"
 
 [weakdeps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -571,26 +571,40 @@ Defined by [ADTypes.jl](https://github.com/SciML/ADTypes.jl).
 
 # Constructors
 
-    AutoHyperHessians(; chunksize=nothing)
+    AutoHyperHessians(; chunksize=nothing, simd=false, jet=false)
 
 # Type parameters
 
   - `chunksize`: the preferred chunk size to evaluate several derivatives at once. If `nothing`, HyperHessians chooses automatically.
-"""
-struct AutoHyperHessians{chunksize} <: AbstractADType end
 
-function AutoHyperHessians(; chunksize::Union{Nothing, Int} = nothing)
+# Fields
+
+  - `simd::Bool`: whether to force `SIMD.Vec` arithmetic for the derivative components (only effective for `Float32`/`Float64` elements).
+  - `jet::Bool`: whether to use the symmetric jet representation, which computes a whole Hessian in a single function evaluation. Only sensible for small inputs; ignores `chunksize` for Hessian computations.
+"""
+struct AutoHyperHessians{chunksize} <: AbstractADType
+    simd::Bool
+    jet::Bool
+end
+
+function AutoHyperHessians(;
+        chunksize::Union{Nothing, Int} = nothing, simd::Bool = false, jet::Bool = false
+    )
     if chunksize isa Int
         chunksize > 0 || throw(ArgumentError("chunksize must be positive, got $chunksize"))
     end
-    return AutoHyperHessians{chunksize}()
+    return AutoHyperHessians{chunksize}(simd, jet)
 end
 
 mode(::AutoHyperHessians) = ForwardMode()
 
-function Base.show(io::IO, ::AutoHyperHessians{chunksize}) where {chunksize}
+function Base.show(io::IO, backend::AutoHyperHessians{chunksize}) where {chunksize}
+    options = String[]
+    chunksize !== nothing && push!(options, "chunksize=" * repr(chunksize; context = io))
+    backend.simd && push!(options, "simd=true")
+    backend.jet && push!(options, "jet=true")
     print(io, AutoHyperHessians, "(")
-    chunksize !== nothing && print(io, "chunksize=", repr(chunksize; context = io))
+    join(io, options, ", ")
     return print(io, ")")
 end
 

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -172,6 +172,13 @@ end
     @test ad isa AbstractADType
     @test ad isa AutoHyperHessians{8}
     @test mode(ad) isa ForwardMode
+    @test ad.simd == false
+    @test ad.jet == false
+
+    ad = AutoHyperHessians(; chunksize = 8, simd = true, jet = true)
+    @test ad isa AutoHyperHessians{8}
+    @test ad.simd == true
+    @test ad.jet == true
 
     @test_throws ArgumentError AutoHyperHessians(; chunksize = -1)
 end

--- a/test/shared/test_setup.jl
+++ b/test/shared/test_setup.jl
@@ -71,6 +71,7 @@ function every_ad_with_options()
         AutoGTPSA(descriptor = Val(:descriptor)),
         AutoHyperHessians(),
         AutoHyperHessians(chunksize = 8),
+        AutoHyperHessians(chunksize = 8, simd = true, jet = true),
         AutoMooncake(; config = :config),
         AutoMooncakeForward(; config = :config),
         AutoPolyesterForwardDiff(),


### PR DESCRIPTION
HyperHessians 0.3 gained a `simd` config option forcing SIMD.Vec
arithmetic and an explicit opt-in `Jet` representation computing a full
Hessian in one evaluation. Expose both as Bool fields on
AutoHyperHessians so DifferentiationInterface can forward them. They
stay fields rather than type parameters: unlike chunksize they never
need to reach the type domain at the ADTypes level, and a Bool branch
union-splits where an arbitrary Int cannot.


