### PR TITLE
QA: remove deprecated JET target override

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -23,7 +23,6 @@ end
 run_qa(
     ADTypes;
     aqua_kwargs = (; deps_compat = (; check_extras = false)),
-    jet_kwargs = (; target_defined_modules = true),
     # Four unavoidable non-public names, ignored only in the public-API access check
     # (every other ExplicitImports check passes unignored):
     #   * `broadcastable` — the documented broadcasting customization hook;


### PR DESCRIPTION
## Summary\n\nRemove the obsolete jet_kwargs target_defined_modules=true override. SciMLTesting already supplies target_modules=(ADTypes,) by default; the old keyword emitted JET's deprecation warning.\n\n## Verification\n\n- Baseline GROUP=QA julia --project Pkg.test: QA 23 passed, 23 total; emitted JET target_defined_modules configuration is deprecated.\n- Final same command: QA 23 passed, 23 total; no deprecation warning.\n- Runic check on test/qa/qa.jl: passed.\n- typos test/qa/qa.jl: passed.\n- docs/make.jl: passed; Documenter skipped deployment outside CI.\n\nPlease ignore this draft until reviewed by @ChrisRackauckas.