### PR TITLE
Add PrecompileTools workload

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com>, Guillaume Dalle and contributors"]
 version = "1.23.0"
 
+[deps]
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+
 [weakdeps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
@@ -17,6 +20,7 @@ ADTypesEnzymeCoreExt = "EnzymeCore"
 ChainRulesCore = "1.0.2"
 ConstructionBase = "1.5"
 EnzymeCore = "0.5.3,0.6,0.7,0.8"
+PrecompileTools = "1.2.1"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "2.4"
 Setfield = "1"

--- a/src/ADTypes.jl
+++ b/src/ADTypes.jl
@@ -32,6 +32,7 @@ include("dense.jl")
 include("sparse.jl")
 include("legacy.jl")
 include("symbols.jl")
+include("precompile.jl")
 
 # Automatic Differentiation
 export AbstractADType

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,29 @@
+using PrecompileTools: @compile_workload
+
+@compile_workload begin
+    forward_ad = AutoForwardDiff(; chunksize = 4)
+    mode(forward_ad)
+    mode(AutoReverseDiff(; compile = true))
+    Auto(:ForwardDiff)
+    Auto(nothing)
+
+    sparse_ad = AutoSparse(forward_ad)
+    dense_ad(sparse_ad)
+    sparsity_detector(sparse_ad)
+    coloring_algorithm(sparse_ad)
+
+    x = [1.0, 2.0]
+    f = x -> [x[1]^2, x[2]^2]
+    jacobian_sparsity(f, x, NoSparsityDetector())
+    hessian_sparsity(sum, x, NoSparsityDetector())
+
+    pattern = trues(2, 2)
+    jacobian_sparsity(f, x, KnownJacobianSparsityDetector(pattern))
+    hessian_sparsity(sum, x, KnownHessianSparsityDetector(pattern))
+
+    matrix = trues(2, 3)
+    coloring = NoColoringAlgorithm()
+    column_coloring(matrix, coloring)
+    row_coloring(matrix, coloring)
+    symmetric_coloring(pattern, coloring)
+end

--- a/test/precompile_workload.jl
+++ b/test/precompile_workload.jl
@@ -1,0 +1,33 @@
+using ADTypes
+using ADTypes: Auto, AutoForwardDiff, AutoReverseDiff, AutoSparse, ForwardMode,
+    ReverseMode, NoAutoDiff, dense_ad, sparsity_detector, coloring_algorithm,
+    NoSparsityDetector, KnownJacobianSparsityDetector,
+    KnownHessianSparsityDetector, jacobian_sparsity, hessian_sparsity,
+    NoColoringAlgorithm, column_coloring, row_coloring, symmetric_coloring, mode
+using Test
+
+forward_ad = AutoForwardDiff(; chunksize = 4)
+@test mode(forward_ad) isa ForwardMode
+@test mode(AutoReverseDiff(; compile = true)) isa ReverseMode
+@test Auto(:ForwardDiff) isa AutoForwardDiff
+@test Auto(nothing) isa NoAutoDiff
+
+sparse_ad = AutoSparse(forward_ad)
+@test dense_ad(sparse_ad) === forward_ad
+@test sparsity_detector(sparse_ad) isa NoSparsityDetector
+@test coloring_algorithm(sparse_ad) isa NoColoringAlgorithm
+
+x = [1.0, 2.0]
+f(x) = [x[1]^2, x[2]^2]
+@test jacobian_sparsity(f, x, NoSparsityDetector()) == trues(2, 2)
+@test hessian_sparsity(sum, x, NoSparsityDetector()) == trues(2, 2)
+
+pattern = trues(2, 2)
+@test jacobian_sparsity(f, x, KnownJacobianSparsityDetector(pattern)) === pattern
+@test hessian_sparsity(sum, x, KnownHessianSparsityDetector(pattern)) === pattern
+
+matrix = trues(2, 3)
+coloring = NoColoringAlgorithm()
+@test column_coloring(matrix, coloring) == 1:3
+@test row_coloring(matrix, coloring) == 1:2
+@test symmetric_coloring(pattern, coloring) == 1:2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ run_tests(;
         @safetestset "Symbols" include("symbols.jl")
         @safetestset "Legacy" include("legacy.jl")
         @safetestset "Miscellaneous" include("misc.jl")
+        @safetestset "Precompile workload" include("precompile_workload.jl")
         return if VERSION >= v"1.11.0-DEV.469"
             @safetestset "Public" include("public.jl")
         end


### PR DESCRIPTION
## Summary
Adds a PrecompileTools workload covering representative public APIs so the package common execution path is compiled during precompilation.

## Verification
The branch was validated locally with package load/precompile, a focused workload smoke test, and repository checks where available. Runic, typos, and git diff --check were checked for the change.

## Known limitations
No additional limitation was observed in the focused verification.

This draft should be ignored until reviewed by @ChrisRackauckas.