### PR TITLE
Fix AutoChainRules{Int} assertion on 32-bit Julia

### DIFF
--- a/test/symbols.jl
+++ b/test/symbols.jl
@@ -1,7 +1,7 @@
 using ADTypes
 using Test
 
-@test ADTypes.Auto(:ChainRules, 1) isa AutoChainRules{Int64}
+@test ADTypes.Auto(:ChainRules, 1) isa AutoChainRules{Int}
 @test ADTypes.Auto(:Diffractor) isa AutoDiffractor
 @test ADTypes.Auto(:Enzyme) isa AutoEnzyme
 @test ADTypes.Auto(:FastDifferentiation) isa AutoFastDifferentiation


### PR DESCRIPTION
## Summary
- x86 CI fails `ADTypes.Auto(:ChainRules, 1) isa AutoChainRules{Int64}`
- Use `AutoChainRules{Int}` so the type matches native `Int` on both word sizes

## Test plan
- [ ] Core x86 green
- [ ] Existing Core x64 green


Made with [Cursor](https://cursor.com)