### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: ""
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,51 @@
+using ADTypes, BenchmarkTools
+using SparseArrays
+
+const SUITE = BenchmarkGroup()
+
+# =============================================================================
+# Backend construction
+# =============================================================================
+
+SUITE["construct"] = BenchmarkGroup()
+
+SUITE["construct"]["AutoForwardDiff"] = @benchmarkable AutoForwardDiff()
+SUITE["construct"]["AutoFiniteDiff"] = @benchmarkable AutoFiniteDiff()
+SUITE["construct"]["AutoZygote"] = @benchmarkable AutoZygote()
+SUITE["construct"]["AutoEnzyme"] = @benchmarkable AutoEnzyme()
+SUITE["construct"]["AutoForwardDiff_chunk"] = @benchmarkable AutoForwardDiff(
+    chunksize = 8
+)
+SUITE["construct"]["AutoSparse"] = @benchmarkable AutoSparse(AutoForwardDiff())
+
+# =============================================================================
+# Interface queries
+# =============================================================================
+
+SUITE["interface"] = BenchmarkGroup()
+
+afd = AutoForwardDiff()
+asp = AutoSparse(AutoForwardDiff())
+
+SUITE["interface"]["mode"] = @benchmarkable ADTypes.mode($afd)
+SUITE["interface"]["dense_ad"] = @benchmarkable ADTypes.dense_ad($asp)
+SUITE["interface"]["dense_ad_dense"] = @benchmarkable ADTypes.dense_ad($afd)
+
+# =============================================================================
+# Sparsity detection (known-pattern path)
+# =============================================================================
+
+SUITE["sparsity"] = BenchmarkGroup()
+
+N = 100
+f_jac(x) = x .* x
+x_vec = ones(N)
+J_pattern = sparse(ones(N, N))
+detector = ADTypes.KnownJacobianSparsityDetector(J_pattern)
+
+SUITE["sparsity"]["construct_detector"] = @benchmarkable ADTypes.KnownJacobianSparsityDetector(
+    $J_pattern
+)
+SUITE["sparsity"]["jacobian_sparsity"] = @benchmarkable jacobian_sparsity(
+    $f_jac, $x_vec, $detector
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~4s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~4s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md